### PR TITLE
Update Exercise 5 with two correct answers

### DIFF
--- a/learntools/advanced_pandas/summary_functions_maps.py
+++ b/learntools/advanced_pandas/summary_functions_maps.py
@@ -52,12 +52,16 @@ reviews.price.apply(lambda v: v - median_price)""")
 
 
 def check_q6(ans):
-    expected = reviews.loc[(reviews.points / reviews.price).idxmax()].title
+    ratio = reviews.points / reviews.price
+    best = reviews[ratio == ratio.max()]
+    expected = best.title
     return ans == expected
 
 
 def answer_q6():
-    print("""reviews.loc[(reviews.points / reviews.price).idxmax()].title""")
+    print("""ratio = reviews.points / reviews.price
+    reviews[ratio == ratio.max()].title
+    """)
 
 
 def check_q7(ans):


### PR DESCRIPTION
In **Exercise 5** of [Summary functions and maps workbook
](https://www.kaggle.com/residentmario/summary-functions-and-maps-workbook), both review `64590` and review `126096` are correct answers:

```python
ratio = reviews.points / reviews.price
best = reviews[ratio == ratio.max()]
# Actually there are two answer.
best.title
```

output:

```
64590                         Bandit NV Merlot (California)
126096    Cramele Recas 2011 UnWineD Pinot Grigio (Viile...
```