### PR TITLE
CI enhancements

### DIFF
--- a/notebooks/deep_learning/raw/tut4_transfer_learning.ipynb
+++ b/notebooks/deep_learning/raw/tut4_transfer_learning.ipynb
@@ -36,7 +36,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {
     "_kg_hide-output": true,
     "collapsed": true
@@ -67,7 +67,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {
     "_kg_hide-output": true,
     "collapsed": true
@@ -86,30 +86,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Found 72 images belonging to 2 classes.\n",
-      "Found 20 images belonging to 2 classes.\n",
-      "Epoch 1/1\n",
-      "3/3 [==============================] - 13s 4s/step - loss: 0.6244 - acc: 0.6389 - val_loss: 0.2438 - val_acc: 0.9500\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "<tensorflow.python.keras.callbacks.History at 0x133710f98>"
-      ]
-     },
-     "execution_count": 5,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "from tensorflow.python.keras.applications.resnet50 import preprocess_input\n",
     "from tensorflow.python.keras.preprocessing.image import ImageDataGenerator\n",
@@ -177,7 +156,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.1"
+   "version": "3.6.5"
   }
  },
  "nbformat": 4,

--- a/notebooks/deep_learning/raw/tut5_data_augmentation.ipynb
+++ b/notebooks/deep_learning/raw/tut5_data_augmentation.ipynb
@@ -134,7 +134,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.1"
+   "version": "3.6.5"
   }
  },
  "nbformat": 4,

--- a/notebooks/lesson_preprocessor.py
+++ b/notebooks/lesson_preprocessor.py
@@ -58,7 +58,13 @@ class LearnLessonPreprocessor(Preprocessor):
 
     def pip_install_lt_hack(self, nb):
         """pip install learntools @ the present branch when running on Kernels"""
-        branch = get_git_branch()
+        try:
+            branch = get_git_branch()
+        except subprocess.CalledProcessError:
+            # This call fails in CI. The reason is unclear, but it's benign enough
+            # that we can just ignore it and forge on.
+            logging.warn("Failed to capture current git branch. Falling back to master.")
+            branch = 'master'
         pkg = 'git+https://github.com/Kaggle/learntools.git@{}'.format(branch)
         self.pip_install_hack(nb, [pkg])
 

--- a/notebooks/test.sh
+++ b/notebooks/test.sh
@@ -30,8 +30,7 @@ do
     # this means that clean.py wasn't run before committing.
     git diff --exit-code --no-color -- $track
     python3 prepare_push.py $track
-    # TODO: Fails due to failure when calling get_git_branch()
-    #python3 render.py $track
+    python3 render.py $track
 done
 
 TESTABLE_NOTEBOOK_TRACKS="deep_learning python pandas machine_learning"

--- a/notebooks/test.sh
+++ b/notebooks/test.sh
@@ -28,7 +28,7 @@ do
     python3 clean.py $track
     # If this fails (i.e. if running clean.py results in changes to the working tree),
     # this means that clean.py wasn't run before committing.
-    git diff --exit-code $track
+    git diff --exit-code --no-color -- $track
     python3 prepare_push.py $track
     # TODO: Fails due to failure when calling get_git_branch()
     #python3 render.py $track

--- a/notebooks/test.sh
+++ b/notebooks/test.sh
@@ -11,7 +11,7 @@ pip3 install $DIR/..
 # The learntools repo is cloned to a read-only location. Various testing steps involve writing,
 # so copy the whole notebooks directory to a writeable location and work from there.
 WORKING_DIR=`mktemp -d`
-cp -r $DIR/.. $WORKING_DIR
+cp -r $DIR/../../learntools $WORKING_DIR
 cd $WORKING_DIR/learntools/notebooks
 
 TMP_DIR=`mktemp -d`

--- a/notebooks/test.sh
+++ b/notebooks/test.sh
@@ -30,7 +30,8 @@ do
     # this means that clean.py wasn't run before committing.
     git diff --exit-code --no-color -- $track
     python3 prepare_push.py $track
-    python3 render.py $track
+    # TODO: Fails due to failure when calling get_git_branch()
+    #python3 render.py $track
 done
 
 TESTABLE_NOTEBOOK_TRACKS="deep_learning python pandas machine_learning"

--- a/notebooks/test.sh
+++ b/notebooks/test.sh
@@ -6,13 +6,15 @@ set -x
 
 # path to the notebook/ directory.
 DIR=`dirname "${BASH_SOURCE[0]}"`
+# Path to the parent (learntools) dir
+LT=$(readlink -f $DIR/..)
 # Install learntools branch
 pip3 install $DIR/..
 # The learntools repo is cloned to a read-only location. Various testing steps involve writing,
 # so copy the whole notebooks directory to a writeable location and work from there.
 WORKING_DIR=`mktemp -d`
-cp -r $DIR/../../learntools $WORKING_DIR
-cd $WORKING_DIR/learntools/notebooks
+cp -r $LT $WORKING_DIR
+cd $WORKING_DIR/input/notebooks
 
 TMP_DIR=`mktemp -d`
 

--- a/notebooks/test.sh
+++ b/notebooks/test.sh
@@ -37,6 +37,12 @@ done
 TESTABLE_NOTEBOOK_TRACKS="deep_learning python pandas machine_learning"
 for track in $TESTABLE_NOTEBOOK_TRACKS
 do
+    # Running the deep learning notebooks is fairly slow (~10-20 minutes), so only
+    # do it if any of the relevant files have changed between this branch and master.
+    if [[ $track == "deep_learning" ]] && git diff --exit-code master -- $track ../learntools/$track; then
+        echo "No changes affecting deep learning track. Skipping running notebooks."
+        continue
+    fi
     cd $track
     ! [[ -a setup_data.sh ]] || ./setup_data.sh
     for nb in `ls raw/*.ipynb`

--- a/notebooks/test.sh
+++ b/notebooks/test.sh
@@ -11,8 +11,8 @@ pip3 install $DIR/..
 # The learntools repo is cloned to a read-only location. Various testing steps involve writing,
 # so copy the whole notebooks directory to a writeable location and work from there.
 WORKING_DIR=`mktemp -d`
-cp -r $DIR $WORKING_DIR
-cd $WORKING_DIR/notebooks
+cp -r $DIR/.. $WORKING_DIR
+cd $WORKING_DIR/learntools/notebooks
 
 TMP_DIR=`mktemp -d`
 

--- a/notebooks/test.sh
+++ b/notebooks/test.sh
@@ -24,6 +24,9 @@ for track in $TRACKS
 do
     # Run each step of the rendering pipeline, to make sure it runs without errors.
     python3 clean.py $track
+    # If this fails (i.e. if running clean.py results in changes to the working tree),
+    # this means that clean.py wasn't run before committing.
+    git diff --exit-code $track
     python3 prepare_push.py $track
     # TODO: Fails due to failure when calling get_git_branch()
     #python3 render.py $track


### PR DESCRIPTION
- skip DL notebooks if untouched
- fail if notebooks were committed without running clean.py
- run render.py in CI as a sanity check (the `get_git_branch` call is still failing, but we can safely ignore it)