### PR TITLE
Refactor assertions

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,7 +17,7 @@ pipeline {
         stage('Initialize Test Environment') {
             steps {
                 sh '''#!/bin/bash
-                # TODO(rosbo): Fetch necessary datasets
+                # Any extra setup steps go here.
                 '''
             }
         }

--- a/learntools/core/README.md
+++ b/learntools/core/README.md
@@ -157,11 +157,3 @@ Reminder: you can programmatically execute a bunch of notebooks from the command
 
     jupyter nbconvert --execute --inplace *.ipynb
 
-# TODO
-
-Stuff that should maybe still be documented:
-- `Problem` vs. `ProblemView`. Reasons for separating them. Cases where you need to interact with the latter.
-- Effective use of the 'data source' hack in Kernels for low-latency learntools updates.
-- `problem_factory` syntax 
-- `MultipartProblem`
-- Technical details of globals binding (and gotchas)

--- a/learntools/core/asserts.py
+++ b/learntools/core/asserts.py
@@ -20,7 +20,7 @@ import numpy as np
 def name_or_var(assert_fn):
     """
     Assert helpers marked with this decorator take a "name" argument, which is a
-    markdown string representing the actual value being checked. It may be a generic
+    markdown string describing the actual value being checked. It may be a generic
     name like "dataframe", or a prose description like "the result of calling `circle_area`",
     or a variable name wrapped in backticks.
 

--- a/learntools/core/asserts.py
+++ b/learntools/core/asserts.py
@@ -4,20 +4,43 @@ Some assertion helpers used in Problem.check implementations.
 TODO: standardize on some conventions for how these helpers are called, and how they
 present information to the user:
     - When showing actual/expected values, do we use the result of str() or repr()?
+        - (Should we truncate the representation in case it's huge?)
     - When showing types, str or repr?
-    - Should assert helpers always require a name for each thing being checked?
-      Can we assume it's a variable name (and wrap it in backticks), or will it
-      sometimes be something prosaic like "dataframe", or "return value"?
 """
 
 import os
 import numbers
 import math
+import functools
+import logging
 
 import pandas as pd
 import numpy as np
 
-def assert_equal(var, actual, expected, failure_factory=None):
+def name_or_var(assert_fn):
+    """
+    Assert helpers marked with this decorator take a "name" argument, which is a
+    markdown string representing the actual value being checked. It may be a generic
+    name like "dataframe", or a prose description like "the result of calling `circle_area`",
+    or a variable name wrapped in backticks.
+
+    The latter case is extremely common, so this decorator adds an optional "var" keyword-arg
+    to the function. Passing var="foo" is a convenient shorthand for name="`foo`". (If you
+    pass a value for "var", you should not also pass a value for "name".)
+    """
+    @functools.wraps(assert_fn)
+    def wrapped(*args, **kwargs):
+        var = kwargs.pop('var', None)
+        if var:
+            if 'name' in kwargs:
+                logging.warn("Function {} received values for keyword args name *and* var. Overwriting original name kwarg.".format(
+                    assert_fn.__name__))
+            kwargs['name'] = '`{}`'.format(var)
+        return assert_fn(*args, **kwargs)
+    return wrapped
+
+@name_or_var
+def assert_equal(actual, expected, name, failure_factory=None):
     """Assert a protean notion of equality specific to the use case of learntools
     checking. Subclasses of EqualityCheckProblem ultimately use this function
     in their check method.
@@ -28,52 +51,57 @@ def assert_equal(var, actual, expected, failure_factory=None):
     # We default to == comparison, but have special cases for certain data types.
     if isinstance(expected, float):
         assert isinstance(actual, numbers.Number), \
-            "Expected `{}` to be a number, but had value `{!r}` (type = `{}`)".format(
-                var, actual, type(actual).__name__)
+            "Expected {} to be a number, but had value `{!r}` (type = `{}`)".format(
+                name, actual, type(actual).__name__)
         check = math.isclose(actual, expected, rel_tol=1e-06)
     elif isinstance(expected, pd.DataFrame):
-        asserts.assert_df_equals(actual, expected, var)
+        assert_df_equals(actual, expected, name)
         return
     elif isinstance(expected, pd.Series):
-        asserts.assert_series_equals(actual, expected, var)
+        assert_series_equals(actual, expected, name)
         return
     elif isinstance(actual, np.ndarray) or isinstance(expected, np.ndarray):
         check = np.array_equal(actual, expected)
     else:
         check = actual == expected
     if failure_factory:
-        # This optional kwarg is a bit of a hack, currently only used in the 
-        # Python ex1 favourite color question.
-        failure_message = failure_factory(var, actual, expected)
+        # This optional kwarg lets the caller pass a function to generate a custom
+        # failure message. Currently only used in the Python ex1 favourite color question.
+        failure_message = failure_factory(name, actual, expected)
     else:
-        failure_message = "Incorrect value for variable `{}`: `{}`".format(
-                var, repr(actual))
+        failure_message = "Incorrect value for {}: `{}`".format(
+                name, repr(actual))
     assert check, failure_message
 
-def assert_has_columns(df, cols, name=None, strict=False):
-    df_desc = "dataframe"
-    if name:
-        df_desc += ' `{}`'.format(name)
+@name_or_var
+def assert_has_columns(df, cols, name="dataframe", strict=False):
+    """Assert that the given dataframe contains columns with the given names.
+    If strict is True, then assert it has *only* those columns.
+    """
     for col in cols:
         assert col in df.columns, "Expected {} to have column `{}`".format(
-                df_desc, col
+                name, col
                 )
     if strict:
         for col in df.columns:
-            msg = "Unexpected column in {}: `{}`".format(df_desc, col)
+            msg = "Unexpected column in {}: `{}`".format(name, col)
             assert col in cols, msg
 
-def assert_isinstance(cls, **named_things):
-    # TODO: Kind of a bad idea to use kwargs here, because names might not be
-    # valid Python identifiers in some cases.
-    for name, val in named_things.items():
-        assert isinstance(val, cls), "Expected {} to have type `{!r}` but had type `{!r}`".format(name, cls, type(val))
+@name_or_var
+def assert_isinstance(cls, actual, name):
+    assert isinstance(actual, cls), "Expected {} to have type `{!r}` but had type `{!r}`".format(name, cls, type(actual))
 
+@name_or_var
 def assert_is_one_of(actual, options, name):
-    msg = "Incorrect value for `{}`: `{!r}`".format(name, actual)
+    msg = "Incorrect value for {}: `{!r}`".format(name, actual)
     assert actual in options, msg
 
+@name_or_var
 def assert_len(thing, exp_len, name):
+    """Assert that the given thing has the given length.
+
+    PRECONDITION: the thing implements __len__
+    """
     actual = len(thing)
     assert actual == exp_len, "Expected {} to have length {}, but was {}".format(
             name, exp_len, actual,
@@ -88,12 +116,11 @@ def assert_file_exists(path):
     assert os.path.exists(path), msg
     assert os.path.isfile(path), "Expected `{}` to be a file".format(path)
 
-def assert_df_equals(actual, exp, name=None):
-    actual_name = name or "dataframe"
-    assert_isinstance(pd.DataFrame, **{actual_name: actual, "_expected_value": exp})
-    actual_name = '`{}`'.format(name) if name else "dataframe"
+@name_or_var
+def assert_df_equals(actual, exp, name="dataframe"):
+    assert_isinstance(pd.DataFrame, actual, name)
     assert len(actual) == len(exp), "Expected {} to have length {} but was actually {}".format(
-        actual_name, len(exp), len(actual))
+        name, len(exp), len(actual))
     # Only verify that the first n records match - I guess this could be slow if 
     # our dataframes have hundreds of thousands of rows. This *could* bite us, though
     # it seems unlikely to cause a false negative.
@@ -111,18 +138,13 @@ def assert_df_equals(actual, exp, name=None):
     # Check dtype match per column. (This is something that df.equals cares about,
     # though in some cases that might be stricter than what we want. e.g. we might 
     # not care if a column has values [1, 2, 3] in expected and [1., 2., 3.] in actual)
-    assert False, "Incorrect value for dataframe{}".format(' `{}`'.format(name) if name else '')
+    assert False, "Incorrect value for {}".format(name)
 
-def assert_series_equals(actual, exp, name=None):
-    # TODO: Would be nice to standardize on variable names being wrapped in backticks 
-    # at the top of the call stack, so that e.g. we can call assert_isinstance with
-    # a default name like "series" and not have it wrapped in backticks.
-    # TODO: Actually, maybe name should be mandatory for these functions?
-    actual_name = name or 'series'
-    assert_isinstance(pd.Series, **{actual_name: actual, "_expected_value": exp})
-    actual_name = '`{}`'.format(name) if name else "series"
+@name_or_var
+def assert_series_equals(actual, exp, name="series"):
+    assert_isinstance(pd.Series, actual, name=name)
     assert len(actual) == len(exp), "Expected {} to have length {} but was actually {}".format(
-        actual_name, len(exp), len(actual))
+        name, len(exp), len(actual))
     lim = 100
     actual_sub = actual.head(lim)
     exp_sub = exp.head(lim)
@@ -130,7 +152,7 @@ def assert_series_equals(actual, exp, name=None):
     if eq:
         return
     # TODO: More checks
-    assert False, "Incorrect value for {}".format(actual_name)
+    assert False, "Incorrect value for {}".format(name)
 
 # For star import purposes, export only names that begin with assert (i.e. our helper fns)
 __all__ = [name for name in dir() if name.startswith('assert')]

--- a/learntools/core/asserts.py
+++ b/learntools/core/asserts.py
@@ -27,6 +27,17 @@ def name_or_var(assert_fn):
     The latter case is extremely common, so this decorator adds an optional "var" keyword-arg
     to the function. Passing var="foo" is a convenient shorthand for name="`foo`". (If you
     pass a value for "var", you should not also pass a value for "name".)
+
+    Example:
+
+    @name_or_var
+    def assert_negative(actual, name):
+        assert actual < 0, "{} should have been negative, but was actually {}".format(name, actual)
+
+    # The following are all valid calls
+    assert_negative(x, "Bank balance")
+    assert_negative(x, name="`Bank.balance` attribute")
+    assert_negative(x, var="bank_balance") # Equivalent to assert_negative(x, "`bank_balance`")
     """
     @functools.wraps(assert_fn)
     def wrapped(*args, **kwargs):

--- a/learntools/core/multiproblem.py
+++ b/learntools/core/multiproblem.py
@@ -5,7 +5,7 @@ class MultipartProblem:
     
     def __init__(self, *probs):
         self.problems = probs
-        # TODO: This should be ordered.
+        # Mapping from string identifier (e.g. 'a', 'b'...) to ProblemView
         self._prob_map = {}
 
     def _repr_markdown_(self):

--- a/learntools/core/problem.py
+++ b/learntools/core/problem.py
@@ -170,7 +170,7 @@ class EqualityCheckProblem(CodingProblem):
 
     def check(self, *args):
         for (var, actual, expected) in zip(self.injectable_vars, args, self.expected):
-            asserts.assert_equal(var, actual, expected, 
+            asserts.assert_equal(actual, expected, var=var,
                     failure_factory=getattr(self, 'failure_message', None)
                     )
 

--- a/learntools/core/problem.py
+++ b/learntools/core/problem.py
@@ -4,12 +4,7 @@ from abc import ABC, abstractmethod
 # vars, expected.
 # cf. https://stackoverflow.com/questions/43790040/how-to-create-an-abstract-class-attribute-potentially-read-only
 from typing import List
-import math
-import numbers
 import functools
-
-import pandas as pd
-import numpy as np
 
 from learntools.core.richtext import *
 from learntools.core.exceptions import NotAttempted, Uncheckable, UserlandExceptionIncorrect
@@ -173,33 +168,11 @@ class EqualityCheckProblem(CodingProblem):
             assert len(ex) == len(self.injectable_vars)
             return ex
 
-    def failure_message(self, var, actual, expected):
-        return "Incorrect value for variable `{}`: `{}`".format(
-                    var, repr(actual))
-
-    # TODO: Move this logic to asserts.py
-    def assert_equal(self, var, actual, expected):
-        # We default to == comparison, but have special cases for certain data types.
-        if isinstance(expected, float):
-            assert isinstance(actual, numbers.Number), \
-                "Expected `{}` to be a number, but had value `{!r}` (type = `{}`)".format(
-                    var, actual, type(actual).__name__)
-            check = math.isclose(actual, expected, rel_tol=1e-06)
-        elif isinstance(expected, pd.DataFrame):
-            asserts.assert_df_equals(actual, expected, var)
-            return
-        elif isinstance(expected, pd.Series):
-            asserts.assert_series_equals(actual, expected, var)
-            return
-        elif isinstance(actual, np.ndarray) or isinstance(expected, np.ndarray):
-            check = np.array_equal(actual, expected)
-        else:
-            check = actual == expected
-        assert check, self.failure_message(var, actual, expected)
-
     def check(self, *args):
         for (var, actual, expected) in zip(self.injectable_vars, args, self.expected):
-            self.assert_equal(var, actual, expected)
+            asserts.assert_equal(var, actual, expected, 
+                    failure_factory=getattr(self, 'failure_message', None)
+                    )
 
     def check_whether_attempted(self, *args):
         varnames = self.injectable_vars

--- a/learntools/core/problem.py
+++ b/learntools/core/problem.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-# TODO: An annoying limitation of abc is that I can't mark an attribute as abstract, only a property.
+# An annoying limitation of abc is that I can't mark an attribute as abstract, only a property.
 # And I don't want to impose on each problem subclass to go to the work of defining a property for stuff like
 # vars, expected.
 # cf. https://stackoverflow.com/questions/43790040/how-to-create-an-abstract-class-attribute-potentially-read-only
@@ -15,7 +15,7 @@ from learntools.core.richtext import *
 from learntools.core.exceptions import NotAttempted, Uncheckable, UserlandExceptionIncorrect
 from learntools.core import utils, asserts, constants
 
-# TODO: I'm sure there's a more elegant way to do this.
+# I'm sure there's a more elegant way to do this.
 # Some kind of decorator on top of property?
 def optionally_plural_property(obj, name):
     single_attr = getattr(obj, name, None)

--- a/learntools/core/richtext.py
+++ b/learntools/core/richtext.py
@@ -3,7 +3,6 @@ from . import colors
 def colorify(text, color):
     return '<span style="color:{}">{}</span>'.format(color, text)
 
-# TODO: would probably have made more sense to define this as a mixin?
 class RichText:
     """Crucially this defines methods for both rich and plaintext representations.
     If displayed from a code cell, it will render the nice rich output. If in the console,
@@ -39,7 +38,9 @@ class PrefixedRichText(RichText):
     def _repr_markdown_(self):
         if not self.txt:
             # TODO: hm, this fallback behaviour makes sense for Correct and
-            # TestFailure, but not really for the others.
+            # TestFailure, but not really for the others. For classes like
+            # Hint or Solution, we should probably treat the absence of self.txt
+            # as an error condition.
             return colorify(self.label, self.label_color)
         pre = colorify(self.label+':', self.label_color)
         return pre + ' ' + self.txt
@@ -58,8 +59,8 @@ class Hint(PrefixedRichText):
         # Is this one of a series of hints?
         self.is_multi = n > 1 or not last
         if not last:
-            # TODO: include _varname?
-            # TODO: colorify?
+            # TODO: Would be nice to be able to reference the actual name
+            # associated with the ProblemView, e.g. `q2.hint(2)`
             coda = '\n(For another hint, call `.hint({})`)'.format(n+1)
             txt += coda
         super().__init__(txt)

--- a/learntools/embeddings/ex1_embedding_layers.py
+++ b/learntools/embeddings/ex1_embedding_layers.py
@@ -155,8 +155,8 @@ Otherwise, you'll need to figure out what index your bias layer exists at (e.g. 
         EqualityCheckProblem.check_whether_attempted(self, *args)
 
     def check(self, bias_layer):
-        assert_isinstance(keras.layers.Layer, bias_layer=bias_layer)
-        assert_isinstance(keras.layers.Embedding, bias_layer=bias_layer)
+        assert_isinstance(keras.layers.Layer, bias_layer, var='bias_layer')
+        assert_isinstance(keras.layers.Embedding, bias_layer, var='bias_layer')
         exp_shape = (None, 1, 1)
         assert bias_layer.output_shape == exp_shape, ("Expected bias layer to have"
                 " output shape `{}`, but was actually `{}`".format(exp_shape,

--- a/learntools/embeddings/ex2_factorization.py
+++ b/learntools/embeddings/ex2_factorization.py
@@ -23,7 +23,8 @@ class RecommendFunction(CodingProblem):
     def check(self, recommend, model):
         uid = 26556
         recc = recommend(model, uid, n=3)
-        assert_has_columns(recc, ['movieId', 'predicted_rating'])
+        assert_has_columns(recc, ['movieId', 'predicted_rating'], 
+                name="return value of `recommend`")
         assert_len(recc, 3, "result of calling `recommend` with `n=3`")
         # Could check sortedness, but not really an explicit requirement.
         # Erring on the side of false-correct judgements over false-incorrect.
@@ -64,7 +65,8 @@ class RecommendNonObscure(CodingProblem):
     def check(self, recommend, model):
         uid = 26556
         recc = recommend(model, uid, 3)
-        assert_has_columns(recc, ['movieId', 'predicted_rating'])
+        assert_has_columns(recc, ['movieId', 'predicted_rating'], 
+                name="return value of `recommend_nonobscure`")
 
 class L2Intro(ThoughtExperiment):
     _solution = (

--- a/learntools/embeddings/ex3_gensim.py
+++ b/learntools/embeddings/ex3_gensim.py
@@ -22,7 +22,7 @@ What happens if we run something like `kv.most_similar(positive=['Legally Blonde
 """)
 
     def check(self, sim):
-        assert_isinstance(list, legally_impossible=sim)
+        assert_isinstance(list, sim, var='legally_impossible')
         assert len(sim), "Expected `legally_impossible` to be non-empty"
         v0 = sim[0]
         assert isinstance(v0, tuple), "Expected `legally_impossible` to be a list of tuples"
@@ -43,7 +43,7 @@ class CalculateNorms(CodingProblem):
 
     def check(self, norms):
         n_movies = 26744
-        assert_isinstance(np.ndarray, norms=norms)
+        assert_isinstance(np.ndarray, norms, var='norms')
         shape = norms.shape
         exp_shape = (n_movies,)
         assert shape == exp_shape, ("Expected `norms` to have shape `{}`"
@@ -61,7 +61,7 @@ class NormColumn(CodingProblem):
     _solution = CS("all_movies_df['norm'] = norms")
 
     def check(self, df):
-        assert_has_columns(df, ['norm'], 'all_movies_df')
+        assert_has_columns(df, ['norm'], var='all_movies_df')
         exp = 1.623779
         jum = df.loc[1, 'norm']
         assert math.isclose(exp, df.loc[1, 'norm'], rel_tol=.5), (

--- a/learntools/pandas/creating_reading_and_writing.py
+++ b/learntools/pandas/creating_reading_and_writing.py
@@ -38,7 +38,7 @@ items = ['Flour', 'Milk', 'Eggs', 'Spam']
 recipe = pd.Series(quantities, index=items, name='Dinner')""")
 
     def check(self, ings):
-        assert_series_equals(ings, self.recipe)
+        assert_series_equals(ings, self.recipe, var=self._var)
         assert ings.name == self.recipe.name, ("Expected `ingredients` to have"
                 " `name={!r}`, but was actually `{!r}`").format(
                         self.recipe.name, ings.name)
@@ -64,7 +64,8 @@ class SaveAnimalsCsv(CodingProblem):
         actual = pd.read_csv(path, index_col=0)
         expected = pd.DataFrame({'Cows': [12, 20], 'Goats': [22, 19]}, 
                 index=['Year 1', 'Year 2'])
-        assert_df_equals(actual, expected)
+        assert_df_equals(actual, expected, 
+            name="Dataframe loaded from `cows_and_goats.csv`")
 
 class ReadPitchforkSql(EqualityCheckProblem):
     _var = 'music_reviews'

--- a/learntools/pandas/summary_functions_and_maps.py
+++ b/learntools/pandas/summary_functions_and_maps.py
@@ -17,7 +17,7 @@ class UniqueCountries(CodingProblem):
     def check(self, countries):
         # TODO: implement this assert
         #assert_equal_ignoring_order(countries, self.expected_set, self._var)
-        assert_len(countries, len(self.expected_set), self._var)
+        assert_len(countries, len(self.expected_set), var=self._var)
         assert set(countries) == self.expected_set, ("Incorrect value for "
                 "`countries`: `{!r}`").format(countries)
 
@@ -39,13 +39,13 @@ bargain_idx = (reviews.points / reviews.price).idxmax()
 bargain_wine = reviews.loc[bargain_idx, 'title']''')
 
     def check(self, bargain_wine):
-        assert_isinstance(str, bargain_wine=bargain_wine)
+        assert_isinstance(str, bargain_wine, var='bargain_wine')
         # NB: Hard-coding these rather than calculating them dynamically.
         # These two wines are tied for best bargain, each having a points-to-price
         # ratio of 21.5. They'll always get the first one using the idxmax() solution,
         # but may get the Pinot if they use a different method.
         bargains = ['Bandit NV Merlot (California)', 'Cramele Recas 2011 UnWineD Pinot Grigio (Viile Timisului)']
-        assert_is_one_of(bargain_wine, bargains, 'bargain_wine')
+        assert_is_one_of(bargain_wine, bargains, var='bargain_wine')
 
 
 class DescriptorCounts(EqualityCheckProblem):

--- a/notebooks/pandas/raw/creating-reading-and-writing-workbook.ipynb
+++ b/notebooks/pandas/raw/creating-reading-and-writing-workbook.ipynb
@@ -75,7 +75,7 @@
     "cols = ['Apples', 'Bananas']\n",
     "fruits = pd.DataFrame(dat, columns=cols)\n",
     "\n",
-    "q1.check()\n",
+    "q1.assert_check_passed()\n",
     "fruits"
    ]
   },

--- a/notebooks/pandas/raw/indexing-selecting-assigning.ipynb
+++ b/notebooks/pandas/raw/indexing-selecting-assigning.ipynb
@@ -101,7 +101,7 @@
     "# Incorrect\n",
     "desc = reviews.description.values\n",
     "\n",
-    "q1.check()"
+    "q1.assert_check_failed()"
    ]
   },
   {
@@ -114,7 +114,7 @@
     "# Correct\n",
     "desc = reviews.description\n",
     "\n",
-    "q1.check()\n",
+    "q1.assert_check_passed()\n",
     "desc"
    ]
   },
@@ -177,7 +177,7 @@
     "# incorrect (wrong index)\n",
     "first_description = desc[1]\n",
     "\n",
-    "q2.check()\n",
+    "q2.assert_check_failed()\n",
     "first_description"
    ]
   },
@@ -191,7 +191,7 @@
     "# correct\n",
     "first_description = desc.iloc[0]\n",
     "\n",
-    "q2.check()\n",
+    "q2.assert_check_passed()\n",
     "first_description"
    ]
   },
@@ -253,7 +253,7 @@
     "#%%RM_IF(PROD)%%\n",
     "first_row = reviews.iloc[0]\n",
     "\n",
-    "q3.check()\n",
+    "q3.assert_check_passed()\n",
     "first_row"
    ]
   },
@@ -299,7 +299,7 @@
     "#%%RM_IF(PROD)%%\n",
     "first_descriptions = desc.head(10)\n",
     "\n",
-    "q4.check()\n",
+    "q4.assert_check_passed()\n",
     "first_descriptions"
    ]
   },
@@ -325,7 +325,7 @@
     "#%%RM_IF(PROD)%%\n",
     "first_descriptions = desc.iloc[:10]\n",
     "\n",
-    "q4.check()\n",
+    "q4.assert_check_passed()\n",
     "first_descriptions"
    ]
   },
@@ -339,7 +339,7 @@
     "# incorrect\n",
     "first_descriptions = desc.iloc[1:10]\n",
     "\n",
-    "q4.check()\n",
+    "q4.assert_check_failed()\n",
     "first_descriptions"
    ]
   },
@@ -545,7 +545,7 @@
     "#%%RM_IF(PROD)%%\n",
     "italian_wines = reviews[reviews.country == 'Italy']\n",
     "\n",
-    "q8.check()\n",
+    "q8.assert_check_passed()\n",
     "italian_wines"
    ]
   },

--- a/notebooks/python/raw/ex_1.ipynb
+++ b/notebooks/python/raw/ex_1.ipynb
@@ -21,9 +21,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "print(\"You've successfully run some Python code\")\n",
@@ -50,8 +48,7 @@
    "execution_count": null,
    "metadata": {
     "_kg_hide-input": true,
-    "_kg_hide-output": true,
-    "collapsed": true
+    "_kg_hide-output": true
    },
    "outputs": [],
    "source": [
@@ -81,9 +78,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# create a variable called color with an appropriate value on the line below.\n",
@@ -101,9 +96,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# create a variable called color with an appropriate value on the line below\n",
@@ -126,9 +119,27 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#%%RM_IF(PROD)%%\n",
+    "color = 'red'\n",
+    "q0.assert_check_failed()\n",
+    "\n",
+    "color = 'ni'\n",
+    "q0.check()\n",
+    "\n",
+    "color = 'Blue'\n",
+    "q0.check()\n",
+    "\n",
+    "color = 'blue'\n",
+    "q0.check()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
    "outputs": [],
    "source": [
     "#_COMMENT_IF(PROD)_\n",
@@ -138,13 +149,22 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "#_COMMENT_IF(PROD)_\n",
     "q0.solution()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#%%RM_IF(PROD)%%\n",
+    "color = 'blue'\n",
+    "q0.assert_check_passed()"
    ]
   },
   {
@@ -168,9 +188,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "pi = 3.14159 # approximate\n",
@@ -186,9 +204,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Uncomment and run the lines below if you need help.\n",
@@ -211,9 +227,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "########### Setup code - don't touch this part ######################\n",
@@ -236,9 +250,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "#_COMMENT_IF(PROD)_\n",
@@ -248,9 +260,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "#_COMMENT_IF(PROD)_\n",
@@ -274,9 +284,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "5 - 3 // 2"
@@ -285,9 +293,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "#_COMMENT_IF(PROD)_\n",
@@ -297,9 +303,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "#_COMMENT_IF(PROD)_\n",
@@ -318,9 +322,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "8 - 3 * 2 - 1 + 1"
@@ -329,9 +331,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "#_COMMENT_IF(PROD)_\n",
@@ -341,9 +341,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "#_COMMENT_IF(PROD)_\n",
@@ -366,9 +364,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Variables representing the number of candies collected by alice, bob, and carol\n",
@@ -386,9 +382,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "#_COMMENT_IF(PROD)_\n",
@@ -415,9 +409,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "#7------3"
@@ -435,9 +427,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "#ninety_nine_dashes = \n",
@@ -447,9 +437,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "#_COMMENT_IF(PROD)_\n",
@@ -484,9 +472,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import random\n",
@@ -535,9 +521,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "#_COMMENT_IF(PROD)_\n",
@@ -580,9 +564,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "#_COMMENT_IF(PROD)_\n",

--- a/notebooks/test.sh
+++ b/notebooks/test.sh
@@ -17,7 +17,7 @@ cd $WORKING_DIR/notebooks
 TMP_DIR=`mktemp -d`
 
 # Install packages the notebook pipeline depends on but which aren't installed with the learntools package.
-pip3 install -r requirements.txt
+pip3 install -q -r requirements.txt
 
 TRACKS="deep_learning embeddings pandas python machine_learning"
 for track in $TRACKS


### PR DESCRIPTION
The main changes in this PR involve refactoring to the assert helpers in `core/asserts.py`, addressing a couple issues:
- ambiguity/inconsistency around how the name of the thing being tested was passed to assertion helpers and what it represented
- a bunch of assertion logic lived in `problem.py` for historical reasons, but really belonged in `asserts.py`.

I also removed a bunch of TODOs sprinkled around the code base, either because they were no longer relevant, or because they were more like an observation or explanation than an actionable item (in which case I left the comment, but removed the 'TODO' tag).

Incidentally, this made me really thankful for our CI testing. A refactor like this would have been incredibly tedious to verify without it.