### PR TITLE
Programmatically add headers and footers to notebooks

### DIFF
--- a/notebooks/MACROS.txt
+++ b/notebooks/MACROS.txt
@@ -17,11 +17,9 @@ EXERCISE_FORKING_URL(N)
 EXERCISE_FORKING_URL
 
 # Some standard boilerplate for beginning and ending exercises/tutorials.
-HEADER
 KEEP_GOING
 EXERCISE_PREAMBLE
 YOURTURN
-FOOTER
 
 ## Line-level macros
 

--- a/notebooks/deep_learning/raw/ex1_convolutions.ipynb
+++ b/notebooks/deep_learning/raw/ex1_convolutions.ipynb
@@ -148,9 +148,7 @@
    "metadata": {},
    "source": [
     "# Keep Going\n",
-    "Now you are ready to **[combine convolutions into powerful models](https://www.kaggle.com/dansbecker/building-models-from-convolutions).** These models are fun to work with, so keep going.\n",
-    "\n",
-    "#$FOOTER$"
+    "Now you are ready to **[combine convolutions into powerful models](https://www.kaggle.com/dansbecker/building-models-from-convolutions).** These models are fun to work with, so keep going.\n"
    ]
   }
  ],

--- a/notebooks/deep_learning/raw/ex3_programming_tf_and_keras.ipynb
+++ b/notebooks/deep_learning/raw/ex3_programming_tf_and_keras.ipynb
@@ -374,9 +374,7 @@
    "metadata": {},
    "source": [
     "# Keep Going\n",
-    "You are ready for **[Transfer Learning](https://www.kaggle.com/dansbecker/transfer-learning/)**, which will allow you to apply the same level of power for your custom purposes.\n",
-    "\n",
-    "#$FOOTER$"
+    "You are ready for **[Transfer Learning](https://www.kaggle.com/dansbecker/transfer-learning/)**, which will allow you to apply the same level of power for your custom purposes.\n"
    ]
   }
  ],

--- a/notebooks/deep_learning/raw/ex4_transfer_learning.ipynb
+++ b/notebooks/deep_learning/raw/ex4_transfer_learning.ipynb
@@ -273,9 +273,7 @@
     "In the next step, we'll see if we can improve on that.\n",
     "\n",
     "# Keep Going\n",
-    "Move on to learn about **[data augmentation](https://www.kaggle.com/dansbecker/data-augmentation/)**.  It is a clever and easy way to improve your models. Then you'll apply data augmentation to this automatic image rotation problem.\n",
-    "\n",
-    "#$FOOTER$"
+    "Move on to learn about **[data augmentation](https://www.kaggle.com/dansbecker/data-augmentation/)**.  It is a clever and easy way to improve your models. Then you'll apply data augmentation to this automatic image rotation problem.\n"
    ]
   }
  ],

--- a/notebooks/deep_learning/raw/ex5_data_augmentation.ipynb
+++ b/notebooks/deep_learning/raw/ex5_data_augmentation.ipynb
@@ -212,9 +212,7 @@
    "metadata": {},
    "source": [
     "# Keep Going\n",
-    "You are ready for **[a deeper understanding of deep learning](https://www.kaggle.com/dansbecker/a-deeper-understanding-of-deep-learning/)**.\n",
-    "\n",
-    "#$FOOTER$"
+    "You are ready for **[a deeper understanding of deep learning](https://www.kaggle.com/dansbecker/a-deeper-understanding-of-deep-learning/)**.\n"
    ]
   }
  ],

--- a/notebooks/deep_learning/raw/ex7_from_scratch.ipynb
+++ b/notebooks/deep_learning/raw/ex7_from_scratch.ipynb
@@ -326,9 +326,7 @@
    "metadata": {},
    "source": [
     "# Keep Going\n",
-    "You are ready to learn about **[strides and dropout](https://www.kaggle.com/dansbecker/dropout-and-strides-for-larger-models)**, which become important as you start using bigger and more powerful models.\n",
-    "\n",
-    "#$FOOTER$"
+    "You are ready to learn about **[strides and dropout](https://www.kaggle.com/dansbecker/dropout-and-strides-for-larger-models)**, which become important as you start using bigger and more powerful models.\n"
    ]
   }
  ],

--- a/notebooks/deep_learning/raw/tut1_intro.ipynb
+++ b/notebooks/deep_learning/raw/tut1_intro.ipynb
@@ -6,8 +6,6 @@
    "source": [
     "# Intro\n",
     "\n",
-    "**This is Lesson 1 in the [Deep Learning](https://www.kaggle.com/education/machine-learning) track.**  \n",
-    "\n",
     "After the end of this lesson, you will understand convolutions. Convolutions are the basic building block for deep learning models in computer vision (and many other applications).\n",
     "\n",
     "After that, we'll quickly progress to using world-class deep learning models.\n",
@@ -34,10 +32,7 @@
    "metadata": {},
    "source": [
     "# Your Turn\n",
-    "After the video, **[test your understanding of convolutions](#$EXERCISE_FORKING_URL$)**\n",
-    "\n",
-    "\n",
-    "#$FOOTER$"
+    "After the video, **[test your understanding of convolutions](#$EXERCISE_FORKING_URL$)**\n"
    ]
   }
  ],

--- a/notebooks/deep_learning/raw/tut2_building_models_from_convolutions.ipynb
+++ b/notebooks/deep_learning/raw/tut2_building_models_from_convolutions.ipynb
@@ -6,8 +6,6 @@
    "source": [
     "# Intro\n",
     "\n",
-    "**This is Lesson 2 in the [Deep Learning](https://www.kaggle.com/learn/deep-learning) track**  \n",
-    "\n",
     "By the end of this lesson, you will understand how convolutions are combined to enable superhuman achievements in computer vision.\n",
     "\n",
     "# Lesson\n"
@@ -31,13 +29,7 @@
    "metadata": {},
    "source": [
     "# Keep Going\n",
-    "Now that you understand the structure of the models, **[learn how to build them](https://www.kaggle.com/dansbecker/programming-in-tensorflow-and-keras)** with TensorFlow and Keras.\n",
-    "\n",
-    "---\n",
-    "\n",
-    "Have questions, comments or feedback?  Bring them to [the Learn forum](https://www.kaggle.com/learn-forum)\n",
-    "\n",
-    "**[Deep Learning Track Home](https://www.kaggle.com/learn/deep-learning)**"
+    "Now that you understand the structure of the models, **[learn how to build them](https://www.kaggle.com/dansbecker/programming-in-tensorflow-and-keras)** with TensorFlow and Keras.\n"
    ]
   }
  ],

--- a/notebooks/deep_learning/raw/tut3_programming_tf_and_keras.ipynb
+++ b/notebooks/deep_learning/raw/tut3_programming_tf_and_keras.ipynb
@@ -6,8 +6,6 @@
    "source": [
     "# Intro\n",
     "\n",
-    "**This is Lesson 3 in the [Deep Learning](https://www.kaggle.com/education/machine-learning) track**  \n",
-    "\n",
     "At the end of this lesson, you will be able to write TensorFlow and Keras code to use one of the best models in computer vision.\n",
     "\n",
     "# Lesson\n"
@@ -131,9 +129,7 @@
    "metadata": {},
    "source": [
     "# Exercise\n",
-    "Now you are ready to **[use a powerful TensorFlow model](#$EXERCISE_FORKING_URL$)** yourself.\n",
-    "\n",
-    "#$FOOTER$"
+    "Now you are ready to **[use a powerful TensorFlow model](#$EXERCISE_FORKING_URL$)** yourself."
    ]
   }
  ],

--- a/notebooks/deep_learning/raw/tut4_transfer_learning.ipynb
+++ b/notebooks/deep_learning/raw/tut4_transfer_learning.ipynb
@@ -6,8 +6,6 @@
    "source": [
     "# Intro\n",
     "\n",
-    "**This is Lesson 4 in the [Deep Learning](https://www.kaggle.com/learn/deep-learning) track**  \n",
-    "\n",
     "At the end of this lesson, you will be able to use transfer learning to build highly accurate computer vision models for your custom purposes, even when you have relatively little data.\n",
     "\n",
     "# Lesson\n"
@@ -134,9 +132,7 @@
    "metadata": {},
    "source": [
     "# Your Turn\n",
-    "**[Try transfer learning](#$EXERCISE_FORKING_URL$)** yourself.\n",
-    "\n",
-    "#$FOOTER$"
+    "**[Try transfer learning](#$EXERCISE_FORKING_URL$)** yourself.\n"
    ]
   }
  ],

--- a/notebooks/deep_learning/raw/tut5_data_augmentation.ipynb
+++ b/notebooks/deep_learning/raw/tut5_data_augmentation.ipynb
@@ -6,8 +6,6 @@
    "source": [
     "# Intro\n",
     "\n",
-    "**This is Lesson 5 in the [Deep Learning](https://www.kaggle.com/learn/machine-learning) track**  \n",
-    "\n",
     "At the end of this lesson, you will be able to use data augmentation. This trick that makes it seem like you have far more data than you actually have, resulting in even better models..\n",
     "\n",
     "# Lesson\n"
@@ -112,9 +110,7 @@
    "metadata": {},
    "source": [
     "# Exercise\n",
-    "Move on to **[apply data augmentation](#$EXERCISE_FORKING_URL$)** yourself.\n",
-    "\n",
-    "#$FOOTER$"
+    "Move on to **[apply data augmentation](#$EXERCISE_FORKING_URL$)** yourself."
    ]
   }
  ],

--- a/notebooks/deep_learning/raw/tut6_deep_understanding.ipynb
+++ b/notebooks/deep_learning/raw/tut6_deep_understanding.ipynb
@@ -6,8 +6,6 @@
    "source": [
     "# Intro\n",
     "\n",
-    "**This is Lesson 6 in the [Deep Learning](https://www.kaggle.com/learn/deep-learning) track**  \n",
-    "\n",
     "At the end of this lesson, you will understand how stochastic gradient descent and back-propagation are used to set the weights in a deep learning model. These topics are complex, but many experts view them as the most important ideas in deep learning.\n",
     "\n",
     "# Lesson\n"

--- a/notebooks/deep_learning/raw/tut7_dl_from_scratch.ipynb
+++ b/notebooks/deep_learning/raw/tut7_dl_from_scratch.ipynb
@@ -5,7 +5,6 @@
    "metadata": {},
    "source": [
     "# Intro\n",
-    "**This is Lesson 7 in the [Deep Learning](https://www.kaggle.com/learn/deep-learning) course**  \n",
     "\n",
     "The models you've built so far have relied on pre-trained models.  But they aren't the ideal solution for many use cases.  In this lesson, you will learn how to build totally new models.\n",
     "\n",
@@ -88,9 +87,7 @@
    "metadata": {},
    "source": [
     "# Your Turn\n",
-    "You are ready to **[build your own model](#$EXERCISE_FORKING_URL$)**.\n",
-    "\n",
-    "#$FOOTER$"
+    "You are ready to **[build your own model](#$EXERCISE_FORKING_URL$)**.\n"
    ]
   }
  ],

--- a/notebooks/deep_learning/raw/tut8_dropout_and_strides.ipynb
+++ b/notebooks/deep_learning/raw/tut8_dropout_and_strides.ipynb
@@ -5,7 +5,6 @@
    "metadata": {},
    "source": [
     "# Intro\n",
-    "**This is Lesson 8 in the [Deep Learning](https://www.kaggle.com/learn/deep-learning) track**  \n",
     "\n",
     "At the end of this lesson, you will understand and know how to use\n",
     "- **Stride lengths** to make your model faster and reduce memory consumption\n",
@@ -95,9 +94,7 @@
    "metadata": {},
    "source": [
     "# Exercise\n",
-    "**[Apply dropout and strides](#$EXERCISE_FORKING_URL$)** yourself while experimenting with larger models.\n",
-    "\n",
-    "#$FOOTER$"
+    "**[Apply dropout and strides](#$EXERCISE_FORKING_URL$)** yourself while experimenting with larger models."
    ]
   }
  ],

--- a/notebooks/machine_learning/raw/ex2.ipynb
+++ b/notebooks/machine_learning/raw/ex2.ipynb
@@ -4,8 +4,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#$HEADER$\n",
-    "\n",
     "This exercise will test your ability to read a data file and understand statistics about the data.\n",
     "\n",
     "In later exercises, you will apply techniques to filter the data, build a machine learning model, and iteratively improve your model.\n",
@@ -177,9 +175,7 @@
     "\n",
     "Check out this **[discussion thread](https://www.kaggle.com/learn-forum/60581)** to see what others think or to add your ideas.\n",
     "\n",
-    "#$KEEP_GOING$\n",
-    "\n",
-    "#$FOOTER$"
+    "#$KEEP_GOING$"
    ]
   }
  ],

--- a/notebooks/machine_learning/raw/ex3.ipynb
+++ b/notebooks/machine_learning/raw/ex3.ipynb
@@ -4,8 +4,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#$HEADER$\n",
-    "\n",
     "## Recap\n",
     "So far, you have loaded your data and reviewed it with the following code. Run this cell to set up your coding environment where the previous step left off."
    ]
@@ -330,9 +328,7 @@
    "source": [
     "It's natural to ask how accurate the model's predictions will be and how you can improve that. That will be you're next step.\n",
     "\n",
-    "#$KEEP_GOING$\n",
-    "\n",
-    "#$FOOTER$"
+    "#$KEEP_GOING$"
    ]
   }
  ],

--- a/notebooks/machine_learning/raw/ex4.ipynb
+++ b/notebooks/machine_learning/raw/ex4.ipynb
@@ -4,8 +4,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#$HEADER$\n",
-    "\n",
     "## Recap\n",
     "You've built a model. In this exercise you will test how good your model is.\n",
     "\n",
@@ -284,9 +282,7 @@
    "source": [
     "Is that MAE good?  There isn't a general rule for what values are good that applies across applications. But you'll see how to use (and improve) this number in the next step.\n",
     "\n",
-    "#$KEEP_GOING$\n",
-    "\n",
-    "#$FOOTER$"
+    "#$KEEP_GOING$"
    ]
   }
  ],

--- a/notebooks/machine_learning/raw/ex5.ipynb
+++ b/notebooks/machine_learning/raw/ex5.ipynb
@@ -4,8 +4,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#$HEADER$\n",
-    "\n",
     "## Recap\n",
     "You've built your first model, and now it's time to optimize the size of the tree to make better predictions. Run this cell to set up your coding environment where the previous step left off."
    ]
@@ -194,9 +192,7 @@
    "source": [
     "You've tuned this model and improved your results. But we are still using Decision Tree models, which are not very sophisticated by modern machine learning standards. In the next step you will learn to use Random Forests to improve your models even more.\n",
     "\n",
-    "#$KEEP_GOING$\n",
-    "\n",
-    "#$FOOTER$"
+    "#$KEEP_GOING$"
    ]
   }
  ],

--- a/notebooks/machine_learning/raw/ex6.ipynb
+++ b/notebooks/machine_learning/raw/ex6.ipynb
@@ -4,8 +4,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#$HEADER$\n",
-    "\n",
     "## Recap\n",
     "Here's the code you've written so far."
    ]
@@ -151,9 +149,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "#$KEEP_GOING$\n",
-    "\n",
-    "#$FOOTER$\n"
+    "#$KEEP_GOING$"
    ]
   }
  ],

--- a/notebooks/machine_learning/raw/ex7.ipynb
+++ b/notebooks/machine_learning/raw/ex7.ipynb
@@ -4,8 +4,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#$HEADER$\n",
-    "\n",
     "# Introduction\n",
     "Machine learning competitions are a great way to improve your data science skills and measure your progress. \n",
     "\n",
@@ -164,9 +162,7 @@
     "# Other Courses\n",
     "The **[Pandas course](https://kaggle.com/Learn/Pandas)** will give you the data manipulation skills to quickly go from conceptual idea to implementation in your data science projects. \n",
     "\n",
-    "You are also ready for the **[Deep Learning](https://kaggle.com/Learn/Deep-Learning)** course, where you will build models with better-than-human level performance at computer vision tasks.\n",
-    "\n",
-    "#$FOOTER$\n"
+    "You are also ready for the **[Deep Learning](https://kaggle.com/Learn/Deep-Learning)** course, where you will build models with better-than-human level performance at computer vision tasks."
    ]
   }
  ],

--- a/notebooks/machine_learning/raw/tut1.ipynb
+++ b/notebooks/machine_learning/raw/tut1.ipynb
@@ -4,8 +4,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#$HEADER$\n",
-    "\n",
     "# Introduction\n",
     "We'll start with an overview of how machine learning models work and how they are used. This may feel basic if you've done statistical modeling or machine learning before. Don't worry, we will progress to building powerful models soon.\n",
     "\n",
@@ -44,9 +42,7 @@
     "The splits and values at the leaves will be determined by the data, so it's time for you to check out the data you will be working with.\n",
     "\n",
     "# Continue\n",
-    "Let's get more specific. It's time to **[Examine Your Data](#$TUTORIAL_URL(1)$)**.\n",
-    "\n",
-    "#$FOOTER$\n"
+    "Let's get more specific. It's time to **[Examine Your Data](#$TUTORIAL_URL(1)$)**.\n"
    ]
   }
  ],

--- a/notebooks/machine_learning/raw/tut2.ipynb
+++ b/notebooks/machine_learning/raw/tut2.ipynb
@@ -4,9 +4,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "**[Machine Learning Course Home Page](kaggle.com/learn/machine-learning)**\n",
-    "\n",
-    "---\n",
     "# Using Pandas to Get Familiar With Your Data\n",
     "\n",
     "The first step in any machine learning project is familiarize yourself with the data.  You'll use the Pandas library for this.  Pandas is the primary tool data scientists use for exploring and manipulating data.  Most people abbreviate pandas in their code as `pd`.  We do this with the command"
@@ -69,9 +66,7 @@
     "\n",
     "\n",
     "# Your Turn\n",
-    "Get started with your **[first coding exercise](#$EXERCISE_FORKING_URL$)**\n",
-    "\n",
-    "#$FOOTER$"
+    "Get started with your **[first coding exercise](#$EXERCISE_FORKING_URL$)**"
    ]
   }
  ],

--- a/notebooks/machine_learning/raw/tut3.ipynb
+++ b/notebooks/machine_learning/raw/tut3.ipynb
@@ -4,10 +4,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "**[Machine Learning Course Home Page](kaggle.com/learn/machine-learning).**\n",
-    "\n",
-    "---\n",
-    "\n",
     "# Selecting Data for Modeling\n",
     "Your dataset had  too many variables to wrap your head around, or even to print out nicely.  How can you pare down this overwhelming amount of data to something you can understand?\n",
     "\n",
@@ -211,9 +207,7 @@
    "metadata": {},
    "source": [
     "# Your Turn\n",
-    "Try it out yourself in the **[Model Building Exercise](#$EXERCISE_FORKING_URL$)**\n",
-    "\n",
-    "#$FOOTER$"
+    "Try it out yourself in the **[Model Building Exercise](#$EXERCISE_FORKING_URL$)**"
    ]
   }
  ],

--- a/notebooks/machine_learning/raw/tut4.ipynb
+++ b/notebooks/machine_learning/raw/tut4.ipynb
@@ -4,10 +4,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "**[Machine Learning Course Home Page](kaggle.com/learn/machine-learning).**\n",
-    "\n",
-    "---\n",
-    "\n",
     "You've built a model. But how good is it?\n",
     "\n",
     "In this lesson, you will learn to use model validation to measure the quality of your model. Measuring model quality is the key to iteratively improving your models.\n",
@@ -158,9 +154,7 @@
    "metadata": {},
    "source": [
     "# Your Turn\n",
-    "Before we look at improving this model, try **[Model Validation](#$EXERCISE_FORKING_URL$)** for yourself.\n",
-    "\n",
-    "#$FOOTER$"
+    "Before we look at improving this model, try **[Model Validation](#$EXERCISE_FORKING_URL$)** for yourself."
    ]
   }
  ],

--- a/notebooks/machine_learning/raw/tut5.ipynb
+++ b/notebooks/machine_learning/raw/tut5.ipynb
@@ -4,10 +4,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "**[Machine Learning Course Home Page](https://kaggle.com/learn/machine-learning).**\n",
-    "\n",
-    "---\n",
-    "\n",
     "At the end of this step, you will understand the concepts of underfitting and overfitting, and you will be able to apply these ideas to make your models more accurate.\n",
     "\n",
     "# Experimenting With Different Models\n",
@@ -134,9 +130,7 @@
     "\n",
     "# Your Turn\n",
     "\n",
-    "Try **[optimizing the model you've previously built](#$EXERCISE_FORKING_URL$)**.\n",
-    "\n",
-    "#$FOOTER$"
+    "Try **[optimizing the model you've previously built](#$EXERCISE_FORKING_URL$)**."
    ]
   }
  ],

--- a/notebooks/machine_learning/raw/tut6.ipynb
+++ b/notebooks/machine_learning/raw/tut6.ipynb
@@ -4,10 +4,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "**[Machine Learning Course Home Page](https://kaggle.com/learn/machine-learning).**\n",
-    "\n",
-    "---\n",
-    "\n",
     "# Introduction\n",
     "\n",
     "Decision trees leave you with a difficult decision. A deep tree with lots of leaves will overfit because each prediction is coming from historical data from only the few houses at its leaf. But a shallow tree with few leaves will perform poorly because it fails to capture as many distinctions in the raw data.\n",
@@ -91,9 +87,7 @@
     "You'll soon learn the XGBoost model, which provides better performance when tuned well with the right parameters (but which requires some skill to get the right model parameters).\n",
     "\n",
     "# Your Turn \n",
-    "Try **[Using a Random Forest model](#$EXERCISE_FORKING_URL$)** yourself and see how much it improves your model.\n",
-    "\n",
-    "#$FOOTER$"
+    "Try **[Using a Random Forest model](#$EXERCISE_FORKING_URL$)** yourself and see how much it improves your model."
    ]
   }
  ],

--- a/notebooks/nb_utils/lesson_preprocessor.py
+++ b/notebooks/nb_utils/lesson_preprocessor.py
@@ -48,13 +48,27 @@ class LearnLessonPreprocessor(Preprocessor):
             c = c and macroer.process_cell(c)
             if c is not None:
                 new_cells.append(c)
+
+        # Add header and footer for self-passed courses, but not for daily-email notebooks (where it'd be confusing)
+        if not self.cfg.get('daily'):
+            self.add_header_and_footer(new_cells)
+
         nb.cells = new_cells
         # NB: There may be some cases where we need to access learntools in a tutorial
-        # or ancillary notebook as well. Could encode this in track_meta, or if we wanted
-        # to be really clever, could look for learntools imports in code cells.
+        # or ancillary notebook as well. We encode this in track_meta. 
         if track_cfg.get('development', False) and nb_meta.type == 'exercise':
             self.pip_install_lt_hack(nb)
         return nb, resources
+
+    def add_header_and_footer(self, cells):
+        """Returns a list of cells with a header cell first, followed by cells (which is a list), followed by a footer cell"""
+        course_info ="""**[{} Course Home Page]({})**""".format(self.track.course_name, self.track.course_url)
+ 
+        header_content = course info + "\n---"
+        footer_content = "---\n" + course_info
+        header_cell = make_cell(cell_type='markdown', source=header_content)
+        footer_cell = make_cell(cell_type='markdown', source=footer_content)
+        return header_cell + cells + footer_cells
 
     def pip_install_lt_hack(self, nb):
         """pip install learntools @ the present branch when running on Kernels"""
@@ -84,26 +98,32 @@ class LearnLessonPreprocessor(Preprocessor):
                 'import sys\n',
                 "sys.path.append('/kaggle/working')",
         ]
-        syspath_cell = self.make_code_cell(source=syspath_lines)
+        syspath_cell = self.make_cell(cell_type='code', source=syspath_lines)
         extra_cells.append(syspath_cell)
         nb.cells = extra_cells + nb.cells
 
     @classmethod
     def pip_install_cell(cls, pkg_spec):
         cmd = '!pip install -U -t /kaggle/working/ {}'.format(pkg_spec)
-        return cls.make_code_cell(source=[cmd])
+        return cls.make_cell(cell_type='code', source=[cmd])
 
     @staticmethod
-    def make_code_cell(**kwargs):
+    def make_cell(cell_type, **kwargs):
+        """Returns a NotebookNode object populated with kwargs. cell_type should be either 'markdown' or 'code'"""
         defaults = dict(
-                cell_type="code",
-                execution_count=None,
+                cell_type=cell_type,
                 metadata={},
                 source=[],
-                outputs=[],
                 )
+        if cell_type == "code":
+            defaults = dict(
+                    execution_count=None,
+                    outputs=[],
+                    )
+            
         defaults.update(kwargs)
         return nbformat.from_dict(defaults)
+        
 
     def process_cell(self, cell):
         # Find all things that look like macros
@@ -215,25 +235,6 @@ This course is still in beta, so I'd love to get your feedback. If you have a mo
         return """These exercises accompany the tutorial on [{}]({}).""".format(
                 self.lesson.topic, self.lesson.tutorial.url,
                 )
-
-    def HEADER(self, **kwargs):
-        # daily users aren't linked back to course main page
-        if self.cfg.get('daily'):
-            return ''
-        else:
-            return """**[{} Course Home Page]({})**
-
----
-""".format(self.track.course_name, self.track.course_url)
-
-    def FOOTER(self, **kwargs):
-        # daily users aren't linked back to course main page
-        if self.cfg.get('daily'):
-            return ''
-        else:
-            return """---
-**[{} Course Home Page]({})**
-""".format(self.track.course_name, self.track.course_url)
 
     def KEEP_GOING(self, **kwargs):
 

--- a/notebooks/nb_utils/lesson_preprocessor.py
+++ b/notebooks/nb_utils/lesson_preprocessor.py
@@ -49,7 +49,7 @@ class LearnLessonPreprocessor(Preprocessor):
             if c is not None:
                 new_cells.append(c)
 
-        # Add header and footer for self-passed courses, but not for daily-email notebooks (where it'd be confusing)
+        # Add header and footer for self-paced courses, but not for daily-email notebooks (where it'd be confusing)
         if not self.cfg.get('daily'):
             self.add_header_and_footer(new_cells)
 
@@ -61,14 +61,15 @@ class LearnLessonPreprocessor(Preprocessor):
         return nb, resources
 
     def add_header_and_footer(self, cells):
-        """Returns a list of cells with a header cell first, followed by cells (which is a list), followed by a footer cell"""
-        course_info ="""**[{} Course Home Page]({})**""".format(self.track.course_name, self.track.course_url)
- 
-        header_content = course info + "\n---"
-        footer_content = "---\n" + course_info
-        header_cell = make_cell(cell_type='markdown', source=header_content)
-        footer_cell = make_cell(cell_type='markdown', source=footer_content)
-        return header_cell + cells + footer_cells
+        """Inserts header cell at front of cells and appends footer cell to end. Both new cells have course links"""
+        course_link ="""**[{} Course Home Page]({})**\n\n""".format(self.track.course_name, self.track.course_url)
+        horizontal_line_break = "---\n"
+        header_content = course_link + horizontal_line_break
+        footer_content = horizontal_line_break + course_link
+        header_cell = self.make_cell(cell_type='markdown', source=header_content)
+        footer_cell = self.make_cell(cell_type='markdown', source=footer_content)
+        cells.insert(0, header_cell)
+        cells.append(footer_cell)
 
     def pip_install_lt_hack(self, nb):
         """pip install learntools @ the present branch when running on Kernels"""
@@ -81,7 +82,6 @@ class LearnLessonPreprocessor(Preprocessor):
             branch = 'master'
         pkg = 'git+https://github.com/Kaggle/learntools.git@{}'.format(branch)
         self.pip_install_hack(nb, [pkg])
-
     def pip_install_hack(self, nb, pkgs):
         """Insert some cells at the top of this notebook that pip install the given
         packages to /kaggle/working, then add that directory to sys.path.
@@ -116,10 +116,8 @@ class LearnLessonPreprocessor(Preprocessor):
                 source=[],
                 )
         if cell_type == "code":
-            defaults = dict(
-                    execution_count=None,
-                    outputs=[],
-                    )
+            defaults['execution_count'] = None
+            defaults['outputs'] = []
             
         defaults.update(kwargs)
         return nbformat.from_dict(defaults)

--- a/notebooks/pandas/raw/renaming-and-combining-reference.ipynb
+++ b/notebooks/pandas/raw/renaming-and-combining-reference.ipynb
@@ -29,9 +29,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "source": [
     "## Renaming\n",
     "\n",
@@ -170,5 +168,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 1
+ "nbformat_minor": 2
 }

--- a/notebooks/python/raw/ex_1.ipynb
+++ b/notebooks/python/raw/ex_1.ipynb
@@ -577,9 +577,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#$KEEP_GOING$\n",
-    "\n",
-    "#$FOOTER$"
+    "#$KEEP_GOING$"
    ]
   }
  ],

--- a/notebooks/python/raw/ex_2.ipynb
+++ b/notebooks/python/raw/ex_2.ipynb
@@ -587,9 +587,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#$KEEP_GOING$\n",
-    "\n",
-    "#$FOOTER$"
+    "#$KEEP_GOING$"
    ]
   }
  ],

--- a/notebooks/python/raw/ex_3.ipynb
+++ b/notebooks/python/raw/ex_3.ipynb
@@ -651,9 +651,7 @@
    "source": [
     "How high can you get your win rate? Share your results on the [forums](https://www.kaggle.com/learn-forum).\n",
     "\n",
-    "#$KEEP_GOING$\n",
-    "\n",
-    "#$FOOTER$"
+    "#$KEEP_GOING$"
    ]
   }
  ],

--- a/notebooks/python/raw/ex_4.ipynb
+++ b/notebooks/python/raw/ex_4.ipynb
@@ -292,9 +292,7 @@
    "source": [
     "That's it for lists and tuples! If you have any questions or feedback (or just want to argue about whether Pluto should be a planet), head over to the [forums](https://kaggle.com/learn-forum).\n",
     "\n",
-    "#$KEEP_GOING$\n",
-    "\n",
-    "#$FOOTER$"
+    "#$KEEP_GOING$\n"
    ]
   }
  ],

--- a/notebooks/python/raw/ex_5.ipynb
+++ b/notebooks/python/raw/ex_5.ipynb
@@ -327,9 +327,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#$KEEP_GOING$\n",
-    "\n",
-    "#$FOOTER$"
+    "#$KEEP_GOING$\n"
    ]
   }
  ],

--- a/notebooks/python/raw/ex_6.ipynb
+++ b/notebooks/python/raw/ex_6.ipynb
@@ -578,9 +578,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#$KEEP_GOING$\n",
-    "\n",
-    "#$FOOTER$"
+    "#$KEEP_GOING$\n"
    ]
   }
  ],

--- a/notebooks/python/raw/ex_7.ipynb
+++ b/notebooks/python/raw/ex_7.ipynb
@@ -408,9 +408,7 @@
     "- [Data visualization](https://www.kaggle.com/learn/data-visualisation)\n",
     "- [Deep learning with TensorFlow](https://www.kaggle.com/learn/deep-learning)\n",
     "\n",
-    "Happy Pythoning!\n",
-    "\n",
-    "#$FOOTER$"
+    "Happy Pythoning!\n"
    ]
   }
  ],

--- a/notebooks/python/raw/tut_1.ipynb
+++ b/notebooks/python/raw/tut_1.ipynb
@@ -4,8 +4,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#$HEADER$\n",
-    "\n",
     "Welcome to Kaggle Learn's Python course. This course will cover the fundamental Python skills that you’ll need before jumping in to using Python for data science. These lessons are aimed at those with some previous coding experience who are looking to add Python to their repertoire or level up their Python skills. (If you're a first-time coder, you may find this course a bit too fast-paced. You may want to check out [these \"Python for Non-Programmers\" learning resources](https://wiki.python.org/moin/BeginnersGuide/NonProgrammers).)\n",
     "\n",
     "This first lesson will cover a brief overview of Python syntax, variable assignment, and arithmetic operators. If you have previous Python experience, you may want to [skip straight to the exercise](#$EXERCISE_FORKING_URL$).\n",
@@ -441,9 +439,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#$YOURTURN$\n",
-    "\n",
-    "#$FOOTER$"
+    "#$YOURTURN$\n"
    ]
   }
  ],

--- a/notebooks/python/raw/tut_2.ipynb
+++ b/notebooks/python/raw/tut_2.ipynb
@@ -4,8 +4,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#$HEADER$\n",
-    "\n",
     "# Functions and Getting Help\n",
     "In this lesson, we'll be talking about functions: calling them, defining them, and looking them up using Python's built-in documentation.\n",
     "\n",
@@ -570,9 +568,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#$YOURTURN$\n",
-    "\n",
-    "#$FOOTER$"
+    "#$YOURTURN$\n"
    ]
   }
  ],

--- a/notebooks/python/raw/tut_3.ipynb
+++ b/notebooks/python/raw/tut_3.ipynb
@@ -4,8 +4,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#$HEADER$\n",
-    "\n",
     "# Booleans\n",
     "\n",
     "Python has a type `bool` which can take on one of two values: `True` and `False`."
@@ -386,9 +384,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#$YOURTURN$\n",
-    "\n",
-    "#$FOOTER$"
+    "#$YOURTURN$\n"
    ]
   }
  ],

--- a/notebooks/python/raw/tut_4.ipynb
+++ b/notebooks/python/raw/tut_4.ipynb
@@ -4,8 +4,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#$HEADER$\n",
-    "\n",
     "# Lists\n",
     "\n",
     "Lists in Python represent ordered sequences of values. They can be defined with comma-separated values between square brackets. For example, here is a list of the first few prime numbers:"
@@ -728,9 +726,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#$YOURTURN$\n",
-    "\n",
-    "#$FOOTER$"
+    "#$YOURTURN$\n"
    ]
   }
  ],

--- a/notebooks/python/raw/tut_5.ipynb
+++ b/notebooks/python/raw/tut_5.ipynb
@@ -4,8 +4,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#$FOOTER$\n",
-    "\n",
     "# Loops\n",
     "\n",
     "Loops are a way to repeatedly execute some code statement."
@@ -511,9 +509,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#$YOURTURN$\n",
-    "\n",
-    "#$FOOTER$"
+    "#$YOURTURN$\n"
    ]
   }
  ],

--- a/notebooks/python/raw/tut_6.ipynb
+++ b/notebooks/python/raw/tut_6.ipynb
@@ -4,8 +4,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#$HEADER$\n",
-    "\n",
     "This lesson will be a double-shot of essential Python types: **strings** and **dictionaries**."
    ]
   },
@@ -658,9 +656,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#$YOURTURN$\n",
-    "\n",
-    "#$FOOTER$"
+    "#$YOURTURN$\n"
    ]
   }
  ],

--- a/notebooks/python/raw/tut_7.ipynb
+++ b/notebooks/python/raw/tut_7.ipynb
@@ -4,8 +4,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#$HEADER$\n",
-    "\n",
     "In this lesson, I'll be talking about **imports** in Python, giving some tips for working with unfamiliar libraries (and the objects they return), and digging into the guts of Python just a bit to talk about **operator overloading**."
    ]
   },
@@ -563,9 +561,7 @@
    "source": [
     "# Your turn!\n",
     "\n",
-    "Head over to [the very last Exercises notebook](#$EXERCISE_FORKING_URL$) for one more round of coding questions involving imports, working with unfamiliar objects, and, of course, more gambling. \n",
-    "\n",
-    "#$FOOTER$"
+    "Head over to [the very last Exercises notebook](#$EXERCISE_FORKING_URL$) for one more round of coding questions involving imports, working with unfamiliar objects, and, of course, more gambling."
    ]
   }
  ],


### PR DESCRIPTION
We previously had inconsistent use of headers and footers in learn notebooks (both in terms of formatting, and whether the headers and footers existed). We previously had macros for HEADER and FOOTER, but those were not widely used.

This PR programmatically adds footers and headers in notebooks/nb_utils/lesson_preprocessor.py and removes the old header/footer markdown and macros from individual notebooks.


