### PR TITLE
Change a "back to course" link and fix typoes

### DIFF
--- a/notebooks/ml_level_2/raw/partial-dependence-plots.ipynb
+++ b/notebooks/ml_level_2/raw/partial-dependence-plots.ipynb
@@ -75,11 +75,11 @@
     "\n",
     "**The partial dependence plot is calculated only after the model has been fit.**  The model is fit on real data.  In that real data, houses in different parts of town may differ in myriad ways (different ages, sizes, etc.)  But after the model is fit, we could start by taking all the characteristics of a single house.  Say, a house with 2 bedrooms, 2 bathrooms, a large lot, an age of 10 years, etc. \n",
     "\n",
-    "We then use the model to predict the price of that house, but we change the distance variable before making a prediction.  We first predict the price for that house when sitting distance to 4.  We then predict it's price setting distance to 5.  Then predict again for 6.  And so on.  We trace out how predicted price changes (on the vertical axis) as we move from small values of distance to large values (on the horizontal axis).\n",
+    "We then use the model to predict the price of that house, but we change the distance variable before making a prediction.  We first predict the price for that house when setting distance to 4.  We then predict it's price setting distance to 5.  Then predict again for 6.  And so on.  We trace out how predicted price changes (on the vertical axis) as we move from small values of distance to large values (on the horizontal axis).\n",
     "\n",
     "In this description, we used only a single house.  But because of interactions, the partial dependence plot for a single house may be atypical.  So, instead we repeat that mental experiment with multiple houses, and we plot the average predicted price on the vertical axis.  You'll see some negative numbers.  That doesn't mean the price would sell for a negative price.  Instead it means the prices would have been less than the actual average price for that distance.\n",
     "\n",
-    "In the left graph, we see house prices fall as we get further from the central business distract.  Though there seems to be a nice suburb about 16 kilometers out, where home prices are higher than many nearer and further suburbs.\n",
+    "In the left graph, we see house prices fall as we get further from the central business district.  Though there seems to be a nice suburb about 16 kilometers out, where home prices are higher than many nearer and further suburbs.\n",
     "\n",
     "The right graph shows the impact of building area, which is interpreted similarly.  A larger building area means higher prices.\n",
     "\n",
@@ -203,7 +203,7 @@
     "# Your Turn\n",
     "Pick three predictors in your project.  Formulate an hypothesis about what the partial dependence plot will look like.  Create the plots, and check the results against your hypothesis.\n",
     "\n",
-    "Once you've done that, **[click here](https://www.kaggle.com/dansbecker/learn-machine-learning)** to return to Learning Machine Learning, where you will keep improving your results."
+    "Once you've done that, **[click here](https://www.kaggle.com/learn/machine-learning)** to return to Learning Machine Learning, where you will keep improving your results."
    ]
   }
  ],


### PR DESCRIPTION
At the end of the tutorial we point to an older link at the bottom:
Once you've done that, click **here** to return to Learning Machine Learning

The PR changes that link from 
https://www.kaggle.com/dansbecker/learn-machine-learning
to
https://www.kaggle.com/learn/machine-learning

The older page says that it is part of an "Older" tutorial. 