### PR TITLE
Add link back to main course and fix a typo

### DIFF
--- a/notebooks/ml_level_2/raw/cross-validation.ipynb
+++ b/notebooks/ml_level_2/raw/cross-validation.ipynb
@@ -41,7 +41,7 @@
     "We then run a second experiment, where we hold out data from the second fold (using everything except the 2nd fold for training the model.) This gives us a second estimate of model quality.\n",
     "We repeat this process, using every fold once as the holdout.  Putting this together, 100% of the data is used as a holdout at some point.  \n",
     "\n",
-    "Returning to our example above from train-test split, if we have 5000 rows of data, we end up with a measure of model quality based on 5000 rows of holdout (even if we don't use all 5000 rows simultaneously.\n",
+    "Returning to our example above from train-test split, if we have 5000 rows of data, we end up with a measure of model quality based on 5000 rows of holdout (even if we don't use all 5000 rows simultaneously).\n",
     "\n",
     "## Trade-offs Between Cross-Validation and Train-Test Split\n",
     "Cross-validation gives a more accurate measure of model quality, which is especially important if you are making a lot of modeling decisions.  However, it can take more time to run, because it estimates models once for each fold.  So it is doing more total work.\n",
@@ -159,7 +159,10 @@
     "# Your Turn\n",
     "1. Convert the code for your on-going project over from train-test split to cross-validation.  Make sure to remove all code that divides your dataset into training and testing datasets.  Leaving code you don't need any more would be sloppy.\n",
     "\n",
-    "2. Add or remove a predictor from your models.  See the cross-validation score using both sets of predictors, and see how you can compare the scores."
+    "2. Add or remove a predictor from your models.  See the cross-validation score using both sets of predictors, and see how you can compare the scores.\n",
+    "\n",
+    "Once you've done this, return to **[Learning Machine Learning](https://www.kaggle.com/learn/machine-learning)**, to keep improving..  \n",
+    "\n"
    ]
   }
  ],


### PR DESCRIPTION
Cross-validation tutorial didn't have the link to go back to the main class (like in other tutorials). 

This PR adds that link, and fixes one tiny typo.