### PR TITLE
Change `home_data` to `y` in ML ex3 SetTarget.check

### DIFF
--- a/learntools/machine_learning/ex3.py
+++ b/learntools/machine_learning/ex3.py
@@ -13,7 +13,7 @@ class SetTarget(CodingProblem):
     _solution = CS('y = home_data.SalePrice')
 
     def check(self, targ):
-        assert isinstance(targ, pd.Series), ("`home_data` should be a Pandas Series "
+        assert isinstance(targ, pd.Series), ("`y` should be a Pandas Series "
                                              "with the actual data. Your current "
                                              "answer is a `{}`").format(type(targ),)
         true_mean = 180921.19589041095


### PR DESCRIPTION
Hi! While I was going through the ML exercises, I got this error:

![image](https://user-images.githubusercontent.com/5009136/54493485-f98c4000-48a6-11e9-9a01-90c879fe051e.png)

What I had been doing was setting the variable `y` to the column *name* `SalesPrice` instead of setting it to the *column*, i.e. `y = 'SalesPrice'` instead of `y = iowa_data['SalesPrice']`. However, the error message above makes it seem that I was re-setting `home_data` to a string. Here's a fix for it.