### PR TITLE
Ensure the released Docker Python image is used.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,7 +17,9 @@ pipeline {
         stage('Initialize Test Environment') {
             steps {
                 sh '''#!/bin/bash
-                # Any extra setup steps go here.
+                    set -exo pipefail
+                    # Ensures the currently released Docker Python image is used.
+                    docker pull gcr.io/kaggle-images/python:latest
                 '''
             }
         }


### PR DESCRIPTION
The Jenkins agent image preload at build time the Docker Python image.

If the Jenkins agent image doesn't have the latest released Docker Python image, this will make sure to download it and run the tests against it.