### PR TITLE
Changes to FE tut2 and ex2. Also make other nbs more in style

### DIFF
--- a/notebooks/feature_engineering/prod.yaml
+++ b/notebooks/feature_engineering/prod.yaml
@@ -1,0 +1,23 @@
+# Rendered ipynb files and kernel metadata json files for this config will be saved at notebooks/<track>/<tag>/
+tag: prod
+public: true
+# If true, then exercise kernels synced to kaggle will have internet enabled and will begin
+# with a cell that pip installs the current learntools branch. (Useful for testing 
+# notebooks on Kernels without requiring image docker deploy for every learntools change)
+development: false
+# By itself, this flag does nothing. But it can be useful to have 'testing' cells in exercise
+# notebooks (testing the checking code on various correct and incorrect solutions) whose 
+# inclusion in the rendered notebook is conditioned on this flag (using a macro like #%%RM_IF(PROD)%%
+# where "prod" is the opposite of "testing")
+testing: false
+# A string to append to titles and slugs of kernels generated under this config (so that the generated
+# kernels are pushed to a separate destination from the default config). If testing is true, suffix 
+# defaults to 'testing'
+#suffix: foo
+# Author username usually gets set in track_meta.py. The following optional key will overwrite
+# the author for kernels generated under this particular config. (Example use case: author A
+# is working on notebooks originally authored by author B. The default 'production' notebooks
+# should keep their original slugs under author B's namespace. But if author A wants to push
+# new testing versions of the notebook, they can set author: author_A in testing.yaml to generate
+# new versions of the kernels under their own username.
+#author: jane_doe

--- a/notebooks/feature_engineering/raw/ex1.ipynb
+++ b/notebooks/feature_engineering/raw/ex1.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Exercise 1: Building a Baseline Model\n",
+    "# Introduction\n",
     "\n",
     "In this exercise, you will develop a baseline model for predicting if a customer will buy an app after clicking on an ad. With this baseline model, you'll be able to see how your feature engineering and selection efforts improve the model's performance."
    ]
@@ -278,7 +278,10 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This will be our baseline score for the model. When we transform features, add new ones, or perform feature selection, we should be improving on this score. However, since this is the test set, we only want to look at it at the end of all our manipulations. At the very end of this course you'll look at the test score again to see if you improved on the baseline model."
+    "This will be our baseline score for the model. When we transform features, add new ones, or perform feature selection, we should be improving on this score. However, since this is the test set, we only want to look at it at the end of all our manipulations. At the very end of this course you'll look at the test score again to see if you improved on the baseline model.\n",
+    "\n",
+    "# Keep Going\n",
+    "Now that you have a baseline model, you are ready to learn **[Categorical Encoding Techniques](#$NEXT_NOTEBOOK_URL$)** to improve it."
    ]
   }
  ],

--- a/notebooks/feature_engineering/raw/ex2.ipynb
+++ b/notebooks/feature_engineering/raw/ex2.ipynb
@@ -4,9 +4,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Exercise 2: Categorical Encodings\n",
+    "# Introduction\n",
     "\n",
-    "In this exercise you'll be applying more advanced encodings to the categorical variables. The goal is to encode the categorical variables in a way that provides more information for the classifier model. The encodings you will implement are:\n",
+    "In this exercise you'll apply more advanced encodings to encode the categorical variables ito improve your classifier model. The encodings you will implement are:\n",
     "\n",
     "- Count Encoding\n",
     "- Target Encoding\n",
@@ -14,14 +14,22 @@
     "- CatBoost Encoding\n",
     "- Feature embedding with SVD \n",
     "\n",
-    "After each encoding, you'll refit the classifier and check its performance on hold-out data. First, run the next cell to repeat the work you did in the last exercise."
+    "You'll refit the classifier after each encoding to check its performance on hold-out data. First, run the next cell to repeat the work you did in the last exercise."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 29,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "WARNING:root:Ignoring repeated attempt to bind to globals\n"
+     ]
+    }
+   ],
    "source": [
     "import numpy as np\n",
     "import pandas as pd\n",
@@ -46,7 +54,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 30,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -100,9 +108,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Baseline model\n",
+      "Training model!\n",
+      "Validation AUC score: 0.9622743228943659\n"
+     ]
+    }
+   ],
    "source": [
     "print(\"Baseline model\")\n",
     "train, valid, test = get_data_splits(clicks)\n",
@@ -122,11 +140,36 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 31,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "application/javascript": [
+       "parent.postMessage({\"jupyterEvent\": \"custom.exercise_interaction\", \"data\": {\"interactionType\": 3, \"questionType\": 4, \"learnTutorialId\": 262, \"questionId\": \"1_LeakageQuestion\", \"learnToolsVersion\": \"0.3.1\", \"valueTowardsCompletion\": 0.0, \"failureMessage\": \"\", \"exceptionClass\": \"\", \"trace\": \"\", \"outcomeType\": 4}}, \"*\")"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Javascript object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "<span style=\"color:#33cc99\">Solution:</span> You should calculate the encodings from the training set only. If you include data from the validation and test sets into the encodings, you'll overestimate the model's performance. You should in general be vigilant to avoid leakage, that is, including any information from the validation and test sets into the model. For a review on this topic, see our lesson on [data leakage](https://www.kaggle.com/alexisbcook/data-leakage)"
+      ],
+      "text/plain": [
+       "Solution: You should calculate the encodings from the training set only. If you include data from the validation and test sets into the encodings, you'll overestimate the model's performance. You should in general be vigilant to avoid leakage, that is, including any information from the validation and test sets into the model. For a review on this topic, see our lesson on [data leakage](https://www.kaggle.com/alexisbcook/data-leakage)"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
-    "#q_1.solution()"
+    "# q_1.solution()"
    ]
   },
   {
@@ -140,19 +183,37 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "application/javascript": [
+       "parent.postMessage({\"jupyterEvent\": \"custom.exercise_interaction\", \"data\": {\"outcomeType\": 4, \"interactionType\": 1, \"questionType\": 1, \"learnTutorialId\": 262, \"questionId\": \"2_CountEncodings\", \"learnToolsVersion\": \"0.3.1\", \"valueTowardsCompletion\": 0.0, \"failureMessage\": \"\", \"exceptionClass\": \"\", \"trace\": \"\"}}, \"*\")"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Javascript object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "<span style=\"color:#ccaa33\">Check:</span> When you've updated the starter code, `check()` will tell you whether your code is correct. You need to update the code that creates variables `train_encoded`, `valid_encoded`"
+      ],
+      "text/plain": [
+       "Check: When you've updated the starter code, `check()` will tell you whether your code is correct. You need to update the code that creates variables `train_encoded`, `valid_encoded`"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
-    "import category_encoders as ce"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
+    "import category_encoders as ce\n",
+    "\n",
     "cat_features = ['ip', 'app', 'device', 'os', 'channel']\n",
     "train, valid, test = get_data_splits(clicks)\n",
     "\n",
@@ -172,7 +233,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -183,9 +244,34 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 32,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "application/javascript": [
+       "parent.postMessage({\"jupyterEvent\": \"custom.exercise_interaction\", \"data\": {\"outcomeType\": 1, \"valueTowardsCompletion\": 0.2, \"interactionType\": 1, \"questionType\": 1, \"learnTutorialId\": 262, \"questionId\": \"2_CountEncodings\", \"learnToolsVersion\": \"0.3.1\", \"failureMessage\": \"\", \"exceptionClass\": \"\", \"trace\": \"\"}}, \"*\")"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Javascript object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "<span style=\"color:#33cc33\">Correct</span>"
+      ],
+      "text/plain": [
+       "Correct"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "#%%RM_IF(PROD)%%\n",
     "cat_features = ['ip', 'app', 'device', 'os', 'channel']\n",
@@ -201,14 +287,23 @@
     "train_encoded = train.join(count_enc.transform(train[cat_features]).add_suffix('_count'))\n",
     "valid_encoded = valid.join(count_enc.transform(valid[cat_features]).add_suffix('_count'))\n",
     "\n",
-    "q_2.check()"
+    "q_2.assert_check_passed()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Training model!\n",
+      "Validation AUC score: 0.9653051135205329\n"
+     ]
+    }
+   ],
    "source": [
     "# Train the model on the encoded datasets\n",
     "# This can take around 30 seconds to complete\n",
@@ -227,6 +322,7 @@
    "metadata": {},
    "source": [
     "## 3) Why is count encoding effective?\n",
+    "At first glance, it could be surprising that Count Encoding helps make accurate models. \n",
     "Why do you think is count encoding is a good idea, or how does it improve the model score?\n",
     "\n",
     "Uncomment the following line after you've decided your answer."
@@ -234,11 +330,46 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 33,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "application/javascript": [
+       "parent.postMessage({\"jupyterEvent\": \"custom.exercise_interaction\", \"data\": {\"interactionType\": 3, \"questionType\": 4, \"learnTutorialId\": 262, \"questionId\": \"3_CountEncodingEffectiveness\", \"learnToolsVersion\": \"0.3.1\", \"valueTowardsCompletion\": 0.0, \"failureMessage\": \"\", \"exceptionClass\": \"\", \"trace\": \"\", \"outcomeType\": 4}}, \"*\")"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Javascript object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "<span style=\"color:#33cc99\">Solution:</span> \n",
+       "    Rare values tend to have similar counts (with values like 1 or 2), so you can classify rare \n",
+       "    values together at prediction time. Common values with large counts are unlikely to have \n",
+       "    the same exact count as other values. So, the common/important values get their own \n",
+       "    grouping.\n",
+       "    "
+      ],
+      "text/plain": [
+       "Solution: \n",
+       "    Rare values tend to have similar counts (with values like 1 or 2), so you can classify rare \n",
+       "    values together at prediction time. Common values with large counts are unlikely to have \n",
+       "    the same exact count as other values. So, the common/important values get their own \n",
+       "    grouping.\n",
+       "    "
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
-    "#q_3.solution()"
+    "# q_3.solution()"
    ]
   },
   {
@@ -252,9 +383,34 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "application/javascript": [
+       "parent.postMessage({\"jupyterEvent\": \"custom.exercise_interaction\", \"data\": {\"outcomeType\": 4, \"interactionType\": 1, \"questionType\": 1, \"learnTutorialId\": 262, \"questionId\": \"4_TargetEncodings\", \"learnToolsVersion\": \"0.3.1\", \"valueTowardsCompletion\": 0.0, \"failureMessage\": \"\", \"exceptionClass\": \"\", \"trace\": \"\"}}, \"*\")"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Javascript object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "<span style=\"color:#ccaa33\">Check:</span> When you've updated the starter code, `check()` will tell you whether your code is correct. You need to update the code that creates variables `train_encoded`, `valid_encoded`"
+      ],
+      "text/plain": [
+       "Check: When you've updated the starter code, `check()` will tell you whether your code is correct. You need to update the code that creates variables `train_encoded`, `valid_encoded`"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "cat_features = ['ip', 'app', 'device', 'os', 'channel']\n",
     "train, valid, test = get_data_splits(clicks)\n",
@@ -276,7 +432,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -287,9 +443,34 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 13,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "application/javascript": [
+       "parent.postMessage({\"jupyterEvent\": \"custom.exercise_interaction\", \"data\": {\"outcomeType\": 1, \"valueTowardsCompletion\": 0.2, \"interactionType\": 1, \"questionType\": 1, \"learnTutorialId\": 262, \"questionId\": \"4_TargetEncodings\", \"learnToolsVersion\": \"0.3.1\", \"failureMessage\": \"\", \"exceptionClass\": \"\", \"trace\": \"\"}}, \"*\")"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Javascript object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "<span style=\"color:#33cc33\">Correct</span>"
+      ],
+      "text/plain": [
+       "Correct"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "#%%RM_IF(PROD)%%\n",
     "cat_features = ['ip', 'app', 'device', 'os', 'channel']\n",
@@ -306,9 +487,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 14,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Training model!\n",
+      "Validation AUC score: 0.9540530347873288\n"
+     ]
+    }
+   ],
    "source": [
     "_ = train_model(train_encoded, valid_encoded)"
    ]
@@ -326,11 +516,58 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 34,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "application/javascript": [
+       "parent.postMessage({\"jupyterEvent\": \"custom.exercise_interaction\", \"data\": {\"interactionType\": 3, \"questionType\": 4, \"learnTutorialId\": 262, \"questionId\": \"5_RemoveIPEncoding\", \"learnToolsVersion\": \"0.3.1\", \"valueTowardsCompletion\": 0.0, \"failureMessage\": \"\", \"exceptionClass\": \"\", \"trace\": \"\", \"outcomeType\": 4}}, \"*\")"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Javascript object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "<span style=\"color:#33cc99\">Solution:</span> \n",
+       "    Target encoding attempts to measure the population mean of the target for each \n",
+       "    level in a categorical feature. This means when there is less data per level, the \n",
+       "    estimated mean will be further away from the \"true\" mean, there will be more variance. \n",
+       "    There is little data per IP address so it's likely that the estimates are much noisier\n",
+       "    than for the other features. The model will rely heavily on this feature since it is \n",
+       "    extremely predictive. This causes it to make fewer splits on other features, and those\n",
+       "    features are fit on just the errors left over accounting for IP address. So, the \n",
+       "    model will perform very poorly when seeing new IP addresses that weren't in the \n",
+       "    training data (which is likely most new data). Going forward, we'll leave out the IP feature when trying\n",
+       "    different encodings.\n",
+       "    "
+      ],
+      "text/plain": [
+       "Solution: \n",
+       "    Target encoding attempts to measure the population mean of the target for each \n",
+       "    level in a categorical feature. This means when there is less data per level, the \n",
+       "    estimated mean will be further away from the \"true\" mean, there will be more variance. \n",
+       "    There is little data per IP address so it's likely that the estimates are much noisier\n",
+       "    than for the other features. The model will rely heavily on this feature since it is \n",
+       "    extremely predictive. This causes it to make fewer splits on other features, and those\n",
+       "    features are fit on just the errors left over accounting for IP address. So, the \n",
+       "    model will perform very poorly when seeing new IP addresses that weren't in the \n",
+       "    training data (which is likely most new data). Going forward, we'll leave out the IP feature when trying\n",
+       "    different encodings.\n",
+       "    "
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
-    "#q_5.solution()"
+    "# q_5.solution()"
    ]
   },
   {
@@ -344,9 +581,34 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 16,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "application/javascript": [
+       "parent.postMessage({\"jupyterEvent\": \"custom.exercise_interaction\", \"data\": {\"outcomeType\": 4, \"interactionType\": 1, \"questionType\": 1, \"learnTutorialId\": 262, \"questionId\": \"6_CatBoostEncodings\", \"learnToolsVersion\": \"0.3.1\", \"valueTowardsCompletion\": 0.0, \"failureMessage\": \"\", \"exceptionClass\": \"\", \"trace\": \"\"}}, \"*\")"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Javascript object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "<span style=\"color:#ccaa33\">Check:</span> When you've updated the starter code, `check()` will tell you whether your code is correct. You need to update the code that creates variables `train_encoded`, `valid_encoded`"
+      ],
+      "text/plain": [
+       "Check: When you've updated the starter code, `check()` will tell you whether your code is correct. You need to update the code that creates variables `train_encoded`, `valid_encoded`"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "train, valid, test = get_data_splits(clicks)\n",
     "\n",
@@ -365,7 +627,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -376,9 +638,34 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 37,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "application/javascript": [
+       "parent.postMessage({\"jupyterEvent\": \"custom.exercise_interaction\", \"data\": {\"outcomeType\": 1, \"valueTowardsCompletion\": 0.2, \"interactionType\": 1, \"questionType\": 1, \"learnTutorialId\": 262, \"questionId\": \"6_CatBoostEncodings\", \"learnToolsVersion\": \"0.3.1\", \"failureMessage\": \"\", \"exceptionClass\": \"\", \"trace\": \"\"}}, \"*\")"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Javascript object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "<span style=\"color:#33cc33\">Correct</span>"
+      ],
+      "text/plain": [
+       "Correct"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "#%%RM_IF(PROD)%%\n",
     "cat_features = ['app', 'device', 'os', 'channel']\n",
@@ -393,14 +680,23 @@
     "train_encoded = train.join(cb_enc.transform(train[cat_features]).add_suffix('_cb'))\n",
     "valid_encoded = valid.join(cb_enc.transform(valid[cat_features]).add_suffix('_cb'))\n",
     "\n",
-    "q_6.check()"
+    "q_6.assert_check_passed()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 19,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Training model!\n",
+      "Validation AUC score: 0.9622743228943659\n"
+     ]
+    }
+   ],
    "source": [
     "_ = train_model(train, valid)"
    ]
@@ -414,7 +710,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -434,7 +730,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 21,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -453,9 +749,34 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 22,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "application/javascript": [
+       "parent.postMessage({\"jupyterEvent\": \"custom.exercise_interaction\", \"data\": {\"outcomeType\": 4, \"interactionType\": 1, \"questionType\": 2, \"learnTutorialId\": 262, \"questionId\": \"7_LearnSVDEmbeddings\", \"learnToolsVersion\": \"0.3.1\", \"valueTowardsCompletion\": 0.0, \"failureMessage\": \"\", \"exceptionClass\": \"\", \"trace\": \"\"}}, \"*\")"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Javascript object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "<span style=\"color:#ccaa33\">Check:</span> When you've updated the starter code, `check()` will tell you whether your code is correct. You need to update the code that creates variables `svd`, `svd_components`"
+      ],
+      "text/plain": [
+       "Check: When you've updated the starter code, `check()` will tell you whether your code is correct. You need to update the code that creates variables `svd`, `svd_components`"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "train, valid, test = get_data_splits(clicks)\n",
     "cat_features = ['app', 'device', 'os', 'channel']\n",
@@ -481,7 +802,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 23,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -492,9 +813,34 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 24,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "application/javascript": [
+       "parent.postMessage({\"jupyterEvent\": \"custom.exercise_interaction\", \"data\": {\"outcomeType\": 1, \"valueTowardsCompletion\": 0.2, \"interactionType\": 1, \"questionType\": 2, \"learnTutorialId\": 262, \"questionId\": \"7_LearnSVDEmbeddings\", \"learnToolsVersion\": \"0.3.1\", \"failureMessage\": \"\", \"exceptionClass\": \"\", \"trace\": \"\"}}, \"*\")"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Javascript object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "<span style=\"color:#33cc33\">Correct</span>"
+      ],
+      "text/plain": [
+       "Correct"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "#%%RM_IF(PROD)%%\n",
     "train, valid, test = get_data_splits(clicks)\n",
@@ -526,9 +872,34 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 25,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "application/javascript": [
+       "parent.postMessage({\"jupyterEvent\": \"custom.exercise_interaction\", \"data\": {\"outcomeType\": 2, \"failureMessage\": \"Please add encoded categorical features to `svd_encodings` dataframe.\", \"interactionType\": 1, \"questionType\": 2, \"learnTutorialId\": 262, \"questionId\": \"8_ApplySVDEncoding\", \"learnToolsVersion\": \"0.3.1\", \"valueTowardsCompletion\": 0.0, \"exceptionClass\": \"\", \"trace\": \"\"}}, \"*\")"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Javascript object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "<span style=\"color:#cc3333\">Incorrect:</span> Please add encoded categorical features to `svd_encodings` dataframe."
+      ],
+      "text/plain": [
+       "Incorrect: Please add encoded categorical features to `svd_encodings` dataframe."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "svd_encodings = pd.DataFrame(index=clicks.index)\n",
     "\n",
@@ -541,7 +912,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 26,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -552,9 +923,34 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 35,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "application/javascript": [
+       "parent.postMessage({\"jupyterEvent\": \"custom.exercise_interaction\", \"data\": {\"outcomeType\": 1, \"valueTowardsCompletion\": 0.2, \"interactionType\": 1, \"questionType\": 2, \"learnTutorialId\": 262, \"questionId\": \"8_ApplySVDEncoding\", \"learnToolsVersion\": \"0.3.1\", \"failureMessage\": \"\", \"exceptionClass\": \"\", \"trace\": \"\"}}, \"*\")"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Javascript object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "<span style=\"color:#33cc33\">Correct</span>"
+      ],
+      "text/plain": [
+       "Correct"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "#%%RM_IF(PROD)%%\n",
     "svd_encodings = pd.DataFrame(index=clicks.index)\n",
@@ -574,7 +970,7 @@
     "# Fill null values with the mean\n",
     "svd_encodings = svd_encodings.fillna(svd_encodings.mean())\n",
     "\n",
-    "q_8.check()"
+    "q_8.assert_check_passed()"
    ]
   },
   {
@@ -586,9 +982,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 28,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Training model!\n",
+      "Validation AUC score: 0.9631219979217012\n"
+     ]
+    }
+   ],
    "source": [
     "train, valid, test = get_data_splits(clicks.join(svd_encodings))\n",
     "_ = train_model(train, valid)"
@@ -598,7 +1003,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Next up, you'll start generating completely new features from the data itself."
+    "# Keep Going\n",
+    "\n",
+    "Now you are ready to **[generating completely new features](#$NEXT_NOTEBOOK_URL$)** from the data itself."
    ]
   }
  ],
@@ -618,7 +1025,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.5"
+   "version": "3.6.8"
   }
  },
  "nbformat": 4,

--- a/notebooks/feature_engineering/raw/ex3.ipynb
+++ b/notebooks/feature_engineering/raw/ex3.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Feature Generation Exercises\n",
+    "# Introduction\n",
     "\n",
     "In this set of exercises, you'll create new features from the existing data. Again you'll compare the score lift for each new feature compared to a baseline model. First off, run the cells below to set up a baseline dataset and model."
    ]
@@ -502,7 +502,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.5"
+   "version": "3.6.8"
   }
  },
  "nbformat": 4,

--- a/notebooks/feature_engineering/raw/ex4.ipynb
+++ b/notebooks/feature_engineering/raw/ex4.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Feature Selection\n",
+    "# Introduction\n",
     "\n",
     "In this exercise you'll use some feature selection algorithms to improve your model. Some of these methods take a while to run so I'll have you write functions which I'll test on small samples."
    ]
@@ -631,7 +631,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.5"
+   "version": "3.6.8"
   }
  },
  "nbformat": 4,

--- a/notebooks/feature_engineering/raw/tut1.ipynb
+++ b/notebooks/feature_engineering/raw/tut1.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Feature Engineering\n",
+    "# Introduction\n",
     "\n",
     "In this micro-course, you will learn a practical approach to feature engineering. You'll be able to apply what you learn to Kaggle competitions as well as building machine learning applications. Through hands-on exercises you will:\n",
     "\n",
@@ -268,7 +268,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In the next exercise, you'll build a baseline model for the TalkingData dataset."
+    "# Your Turn\n",
+    "Now you'll build your own **[baseline model](#$NEXT_NOTEBOOK_URL$)** which you can improve with feature engineering techniques as you go through the course.\n"
    ]
   }
  ],
@@ -288,7 +289,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.5"
+   "version": "3.6.8"
   }
  },
  "nbformat": 4,

--- a/notebooks/feature_engineering/raw/tut2.ipynb
+++ b/notebooks/feature_engineering/raw/tut2.ipynb
@@ -104,7 +104,7 @@
     "\n",
     "Count encoding replaces each categorical value with the number of times it appears in the dataset. For example, if the value \"GB\" occured 10 times in the country feature, then each \"GB\" would be replaced with the number 10.\n",
     "\n",
-    "We'll use the [`categorical-encodings` package](https://github.com/scikit-learn-contrib/categorical-encoding) for most of the work here. However, the current release does not include a count encoder. It should be in the next release, but for now I'll write my own class for count encoding in the style of a scikit-learn transformer.\n"
+    "We'll use the [`categorical-encodings` package](https://github.com/scikit-learn-contrib/categorical-encoding) to get this encoding. The encoder itself is available as `CountEncoder`. This encoder and the others in `categorical-encodings` work like scikit-learn transformers with `.fit` and `.transform` methods."
    ]
   },
   {
@@ -113,45 +113,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "class CountEncoder:\n",
-    "    def __init__(self):\n",
-    "        self.mapping = {}\n",
-    "        \n",
-    "    def fit(self, df):\n",
-    "        \"\"\" Calculates count encodings for each column in a dataframe. \"\"\"\n",
-    "        for col in df.columns:\n",
-    "            self.mapping[col] = df.groupby(col).count().iloc[:, 0]\n",
-    "        \n",
-    "    def transform(self, df):\n",
-    "        \"\"\" Applies learned encodings to a dataframe. Returned datafrom has the same\n",
-    "            indices and columns as original dataframe. \n",
-    "        \"\"\"\n",
-    "        out_df = df.copy()\n",
-    "        for col, encoding in self.mapping.items():\n",
-    "            out_df[col] = df[col].map(self.mapping[col]).fillna(0)\n",
-    "        \n",
-    "        return out_df\n",
-    "    \n",
-    "    def fit_transform(self, df):\n",
-    "        self.fit(df)\n",
-    "        return self.transform(df)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "With that defined we can apply it to our data."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
+    "import category_encoders as ce\n",
     "cat_features = ['category', 'currency', 'country']\n",
-    "count_enc = CountEncoder()\n",
+    "count_enc = ce.CountEncoder()\n",
     "count_encoded = count_enc.fit_transform(ks[cat_features])\n",
     "\n",
     "data = baseline_data.join(count_encoded.add_suffix(\"_count\"))\n",
@@ -178,7 +142,7 @@
     "\n",
     "This technique uses the targets to create new features. So including the validation or test data in the target encodings would be a form of target leakage. Instead, you should learn the target encodings from the training dataset only and apply it to the other datasets.\n",
     "\n",
-    "The `category_encoders` package provides `TargetEncoder` for this. It works like scikit-learn transformers with `.fit` and `.transform` methods."
+    "The `category_encoders` package provides `TargetEncoder` for target encoding. The implementation is similar to `CountEncoder`."
    ]
   },
   {

--- a/notebooks/feature_engineering/raw/tut2.ipynb
+++ b/notebooks/feature_engineering/raw/tut2.ipynb
@@ -4,11 +4,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Categorical Encodings\n",
+    "# Introduction\n",
     "\n",
-    "In this tutorial I'll show you methods for representing categorical variables as numerical features. This will typically improve the performance of your models. In general these encodings will be learned from the data itself. The two most basic encodings are one-hot encoding which you should be familiar with and label encoding which you saw in the first tutorial. Here I'll cover count encoding, target encoding (and variations), and learning encodings with singular value decomposition.\n",
+    "Now that you've built a baseline model, you are ready to improve it with some clever ways to convert categorical variables into numerical features. These encodings will be learned from the data itself. The most basic encodings are one-hot encoding (covered in the [Intermediate Machine Learning](https://www.kaggle.com/learn/intermediate-machine-learning) course) and label encoding which you saw in the first tutorial. \n",
     "\n",
-    "First I'm going to load in the data and rebuild the baseline model from the first tutorial."
+    "Here, you'll learn count encoding, target encoding (and variations), and singular value decomposition.\n",
+    "\n",
+    "Here is the code to rebuild the baseline model from the first tutorial."
    ]
   },
   {
@@ -50,7 +52,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Defining some functions that will help us test our encodings\n",
+    "# Defining  functions that will help us test our encodings\n",
     "import lightgbm as lgb\n",
     "from sklearn import metrics\n",
     "\n",
@@ -100,9 +102,9 @@
    "source": [
     "# Count Encoding\n",
     "\n",
-    "Count encoding replaces each categorical value with the number of times it appears in the dataset. For example, if the value \"GB\" occured 10 times in the country feature, then \"GB\" would be replaced with 10 for each occurence.\n",
+    "Count encoding replaces each categorical value with the number of times it appears in the dataset. For example, if the value \"GB\" occured 10 times in the country feature, then each \"GB\" would be replaced with the number 10.\n",
     "\n",
-    "I'll be using the [`categorical-encodings` package](https://github.com/scikit-learn-contrib/categorical-encoding) for most of the work here. However, the current release does not include a count encoder. It should be in the next release, but for now I'll write my own class for count encoding in the style of a scikit-learn transformer.\n"
+    "We'll use the [`categorical-encodings` package](https://github.com/scikit-learn-contrib/categorical-encoding) for most of the work here. However, the current release does not include a count encoder. It should be in the next release, but for now I'll write my own class for count encoding in the style of a scikit-learn transformer.\n"
    ]
   },
   {
@@ -152,15 +154,8 @@
     "count_enc = CountEncoder()\n",
     "count_encoded = count_enc.fit_transform(ks[cat_features])\n",
     "\n",
-    "data = baseline_data.join(count_encoded.add_suffix(\"_count\"))"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
+    "data = baseline_data.join(count_encoded.add_suffix(\"_count\"))\n",
+    "\n",
     "# Training a model on the baseline data\n",
     "train, valid, test = get_data_splits(data)\n",
     "bst = train_model(train, valid)"
@@ -170,7 +165,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Adding the count encoding features increase the validation score from 0.7467 to 0.7486, a slight improvement!"
+    "Adding the count encoding features increase the validation score from 0.7467 to 0.7486, only a slight improvement."
    ]
   },
   {
@@ -181,7 +176,7 @@
     "\n",
     "Target encoding replaces a categorical value with the average value of the target for that value of the feature. For example, given the country value \"CA\", you'd calculate the average outcome for all the rows with `country == 'CA'`, around 0.28. This is often blended with the target probability over the entire dataset to reduce the variance of values with few occurences.\n",
     "\n",
-    "One thing to note here is that we are using the targets to create new features. This means if we include the validation or test data in the target encodings, information from these datasets will end up in the model (often called leakage). For this reason, I'll learn the target encodings from the training dataset only and apply it to the other datasets.\n",
+    "This technique uses the targets to create new features. So including the validation or test data in the target encodings would be a form of target leakage. Instead, you should learn the target encodings from the training dataset only and apply it to the other datasets.\n",
     "\n",
     "The `category_encoders` package provides `TargetEncoder` for this. It works like scikit-learn transformers with `.fit` and `.transform` methods."
    ]
@@ -192,15 +187,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import category_encoders as ce"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
+    "import category_encoders as ce\n",
     "cat_features = ['category', 'currency', 'country']\n",
     "\n",
     "# Create the encoder itself\n",
@@ -213,24 +200,9 @@
     "\n",
     "# Transform the features, rename the columns with _target suffix, and join to dataframe\n",
     "train = train.join(target_enc.transform(train[cat_features]).add_suffix('_target'))\n",
-    "valid = valid.join(target_enc.transform(valid[cat_features]).add_suffix('_target'))"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "train.head()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
+    "valid = valid.join(target_enc.transform(valid[cat_features]).add_suffix('_target'))\n",
+    "\n",
+    "train.head()\n",
     "bst = train_model(train, valid)"
    ]
   },
@@ -263,15 +235,8 @@
     "target_enc.fit(train[cat_features], train['outcome'])\n",
     "\n",
     "train = train.join(target_enc.transform(train[cat_features]).add_suffix('_cb'))\n",
-    "valid = valid.join(target_enc.transform(valid[cat_features]).add_suffix('_cb'))"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
+    "valid = valid.join(target_enc.transform(valid[cat_features]).add_suffix('_cb'))\n",
+    "\n",
     "bst = train_model(train, valid)"
    ]
   },
@@ -288,9 +253,9 @@
    "source": [
     "# Encoding with Singular Value Decomposition\n",
     "\n",
-    "Now we'll use singular value decomposition (SVD) to learn encodings from pairs of categorical features. SVD encoding is more complex than the other encodings you've learned, but it can also be the most effective. The idea here is we'll construct a matrix of co-occurences for each pair of categorical features. Each row corresponds to a value in feature A, while each column corresponds to a value in feature B. Each element is the count of rows where the value in A appears together with the value in B.\n",
+    "Now we'll use singular value decomposition (SVD) to learn encodings from pairs of categorical features. SVD is more complex than the other encodings you've learned, but it can also be the most effective. We'll construct a matrix of co-occurences for each pair of categorical features. Each row corresponds to a value in feature A, while each column corresponds to a value in feature B. Each element is the count of rows where the value in A appears together with the value in B.\n",
     "\n",
-    "We can use singular value decomposition to find two smaller matrices that equal the count matrix when multiplied.\n",
+    "You then use singular value decomposition to find two smaller matrices that equal the count matrix when multiplied.\n",
     "\n",
     "<center><img src=\"https://i.imgur.com/mnnsBKJ.png\" width=600px></center>\n",
     "\n",
@@ -402,7 +367,8 @@
    "source": [
     "This is the best score yet, 0.7495 compared to baseline of 0.7467. In practice you'd create these encodings for each pair of categorical variables, likely improving the score even more.\n",
     "\n",
-    "Next up, you'll get hands-on practice at encoding categorical features."
+    "# Your Turn\n",
+    "Try **[encoding categorical features](#$NEXT_NOTEBOOK_URL$)** yourself\n"
    ]
   }
  ],
@@ -422,7 +388,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.5"
+   "version": "3.6.8"
   }
  },
  "nbformat": 4,

--- a/notebooks/feature_engineering/raw/tut3.ipynb
+++ b/notebooks/feature_engineering/raw/tut3.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Feature Generation\n",
+    "# Introduction\n",
     "\n",
     "You can provide more information for your model by creating new features from the data itself. For example, you can calculate the number of total projects in the last week and the duration of the fundraising period. The features you can create are different for every dataset so it takes a bit of creativity and experimentation. We're actually a bit limited here since I'm working with only one table. Typically you'll have access to multiple tables with relevant data that you can use to create new features.\n",
     "\n",
@@ -300,7 +300,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.5"
+   "version": "3.6.8"
   }
  },
  "nbformat": 4,

--- a/notebooks/feature_engineering/raw/tut4.ipynb
+++ b/notebooks/feature_engineering/raw/tut4.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Feature Selection\n",
+    "# Introduction\n",
     "\n",
     "Often you'll have dozens or even hundreds of features after various encodings and feature generation. This can lead to two problems. First, the more features you have, the more likely you are to overfit to the training and validation sets. This will cause your model to perform worse at generalizing to new data.\n",
     "\n",
@@ -454,7 +454,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.5"
+   "version": "3.6.8"
   }
  },
  "nbformat": 4,

--- a/notebooks/machine_learning/raw/tut3.ipynb
+++ b/notebooks/machine_learning/raw/tut3.ipynb
@@ -227,7 +227,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.5"
+   "version": "3.6.8"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
@mcleonard Couple things I think you want to do:
[] Remove your own implementation of CountEncoder with the library one.
[] Create a yaml file for the main version of these
[] After you create that yaml file, push it to Kaggle and see how it looks on Kaggle
[] Add Alexis and I as a collaborators on the test (and later the prod) version of these kaggle notebooks, so we can also push.
[] After pushing the notebooks, ask me for the exerciseIds to fill in the checking code
[] Update the exercise so each encoding is added to the previous encodings, rather than overwriting them in the variables `train_encoded` and `val_encoded`.

This is still a really long exercise. It'd be nice if we could make it quicker. One option is to provide more starter code in the SVD exercise, so the user can write less. This is the most time consuming question.

