### PR TITLE
Fix None message showing up on Correct answers

### DIFF
--- a/learntools/core/problem_view.py
+++ b/learntools/core/problem_view.py
@@ -122,6 +122,8 @@ class ProblemView:
             if hasattr(self.problem, '_congrats'):
                 return Correct(self.problem._correct_message,
                                _congrats=self.problem._congrats)
+            else:
+                return Correct(self.problem._correct_message)
 
     def _get_injected_args(self):
         names = self.problem.injectable_vars


### PR DESCRIPTION
Running locally, the output on correct messages is now

```
<IPython.core.display.Javascript object>
Correct
```

Tested locally and on Kaggle in the ML course. We see the intended Correct message. Would like someone else to test as well (both locally and on Kaggle using a testing notebook on a different course)

Then we'll see about getting a new docker image or consider temporarily hacking this in as a Kaggle dataset.