### PR TITLE
Fix typo in problem description

### DIFF
--- a/notebooks/feature_engineering/raw/ex3.ipynb
+++ b/notebooks/feature_engineering/raw/ex3.ipynb
@@ -171,7 +171,7 @@
     "\n",
     "The first feature you'll be creating is the number of events from the same IP in the last six hours. It's likely that someone who is visiting often will download the app.\n",
     "\n",
-    "Implement a function `count_past_events` that takes a Series of click times (timestamps) and returns another Series with the number of events in the last hour. **Tip:** The `rolling` method is useful for this."
+    "Implement a function `count_past_events` that takes a Series of click times (timestamps) and returns another Series with the number of events in the last six hours. **Tip:** The `rolling` method is useful for this."
    ]
   },
   {

--- a/notebooks/feature_engineering/raw/ex3.ipynb
+++ b/notebooks/feature_engineering/raw/ex3.ipynb
@@ -345,7 +345,7 @@
    "source": [
     "### 5) Number of previous app downloads\n",
     "\n",
-    "It's likely that if a visitor downloaded an app previously, it'll affect the likelihood they'll download one again. Implement a function `previous_attributions` that returns a Series with the number of times an app has been download (`'is_attributed' == 1`) before the current event."
+    "It's likely that if a visitor downloaded an app previously, it'll affect the likelihood they'll download one again. Implement a function `previous_attributions` that returns a Series with the number of times an app has been downloaded (`'is_attributed' == 1`) before the current event."
    ]
   },
   {


### PR DESCRIPTION
Some other issues I found:
1. In #5 in this notebook, the first code block has an incomplete sentence
> Returns a series with the
2. In `/notebooks/feature_engineering/raw/ex4.ipynb`, the code block right above _5) Feature Selection with Trees_ returns an error because `selected` is never defined. From looking at it though, it looks like the block was supposed to run without any modification (and `selected` should probably come from the previous block)