### PR TITLE
Remove <hr>

### DIFF
--- a/notebooks/python/raw/ex_1.ipynb
+++ b/notebooks/python/raw/ex_1.ipynb
@@ -149,8 +149,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<hr/>\n",
-    "\n",
     "## 1.\n",
     "\n",
     "Complete the code below. In case it's helpful, here is the table of available arithmetic operations:\n",
@@ -207,7 +205,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<hr/>\n",
     "## 2.\n",
     "\n",
     "Add code to the following cell to swap variables `a` and `b` (so that `a` refers to the object previously referred to by `b` and vice versa)."
@@ -262,7 +259,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<hr/>\n",
     "## 3.\n",
     "\n",
     "a) Add parentheses to the following expression so that it evaluates to 1."
@@ -339,7 +335,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<hr/>\n",
     "## 4. \n",
     "Alice, Bob and Carol have agreed to pool their Halloween candy and split it evenly among themselves.\n",
     "For the sake of their friendship, any candies left over will be smashed. For example, if they collectively\n",


### PR DESCRIPTION
From searching[1] this is the only file that contains `<hr/>`. I don't think we need it.

[1]: https://github.com/Kaggle/learntools/search?q=hr&type=code