### PR TITLE
Add --to flag to nbconvert command.

### DIFF
--- a/notebooks/test.sh
+++ b/notebooks/test.sh
@@ -72,7 +72,7 @@ do
             echo "Warning: skipping $nb in track $track"
             continue
         fi
-        jupyter nbconvert --output-dir "$TMP_DIR" --execute $nb --ExecutePreprocessor.timeout=1000
+        jupyter nbconvert --output-dir "$TMP_DIR" --execute $nb --ExecutePreprocessor.timeout=1000 --to html
     done
     cd ../
 done


### PR DESCRIPTION
Since nbconvert 6.x, this flag is required.

`--to html` is equivalent to default option from `5.x`.