### PR TITLE
Run the learntools test against the staging Docker image.

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 #
-# Run automated tests inside the latest Kaggle Python Docker base image.
+# Run automated tests inside the staging Kaggle Python Docker base image.
 set -e
 set -x
 
 docker run --rm -t \
     -e KAGGLE_USERNAME -e KAGGLE_KEY \
     -v $PWD:/input:ro \
-    gcr.io/kaggle-images/python:latest \
+    gcr.io/kaggle-images/python:staging \
     /bin/bash -c '/input/notebooks/test.sh'


### PR DESCRIPTION
This will allow us to catch failures earlier than at release time.