### PR TITLE
[General] Fix spelling mistake

### DIFF
--- a/notebooks/sql_advanced/raw/ex1.ipynb
+++ b/notebooks/sql_advanced/raw/ex1.ipynb
@@ -208,7 +208,7 @@
     "\n",
     "With this in mind, please fill in the appropriate **JOIN** (i.e., **INNER**, **LEFT**, **RIGHT**, or **FULL**) to return the correct information.  \n",
     "\n",
-    "**Note**: You need only fill in the appropriate **JOIN**.  All other parts of the query should be left as-is.  (You also don't need to write any additional code to run the query, since the `cbeck()` method will take care of this for you.)\n",
+    "**Note**: You need only fill in the appropriate **JOIN**.  All other parts of the query should be left as-is.  (You also don't need to write any additional code to run the query, since the `check()` method will take care of this for you.)\n",
     "\n",
     "To avoid returning too much data, we'll restrict our attention to questions and answers posed in January 2019.  We'll amend the timeframe in Part 2 of this question to be more realistic!"
    ]


### PR DESCRIPTION
The text refers to the `cbeck()` function which does not exist, from the context I assume `check()` was meant.