### PR TITLE
[Intermediate ML] FutureWarning: Criterion 'mae' was deprecated in v1.0 

### DIFF
--- a/learntools/ml_intermediate/ex1.py
+++ b/learntools/ml_intermediate/ex1.py
@@ -18,7 +18,7 @@ class BestModel(CodingProblem):
          "`model_3`, `model_4`, or `model_5`.")
 
         params = best_model.get_params()
-        assert params['n_estimators'] == 100 and params['criterion'] == 'mae' \
+        assert params['n_estimators'] == 100 and (params['criterion'] == 'mae' or params['criterion'] == 'absolute_error') \
         and params['random_state'] == 0, \
         ("Set the value of `best_model` to one of `model_1`, `model_2`, "
          "`model_3`, `model_4`, or `model_5`.  Select the model that gets the lowest MAE.")

--- a/notebooks/ml_intermediate/raw/ex1.ipynb
+++ b/notebooks/ml_intermediate/raw/ex1.ipynb
@@ -97,7 +97,7 @@
     "# Define the models\n",
     "model_1 = RandomForestRegressor(n_estimators=50, random_state=0)\n",
     "model_2 = RandomForestRegressor(n_estimators=100, random_state=0)\n",
-    "model_3 = RandomForestRegressor(n_estimators=100, criterion='mae', random_state=0)\n",
+    "model_3 = RandomForestRegressor(n_estimators=100, criterion='absolute_error', random_state=0)\n",
     "model_4 = RandomForestRegressor(n_estimators=200, min_samples_split=20, random_state=0)\n",
     "model_5 = RandomForestRegressor(n_estimators=100, max_depth=7, random_state=0)\n",
     "\n",


### PR DESCRIPTION
FutureWarning: Criterion 'mae' was deprecated in v1.0 and will be removed in version 1.2. Use criterion='absolute_error' which is equivalent.

https://www.kaggle.com/learn/intermediate-machine-learning/discussion/325974#1795191
https://www.kaggle.com/discussions/product-feedback/323628