### PR TITLE
Use charset_normalizer instead of chardet.

### DIFF
--- a/learntools/data_cleaning/ex4.py
+++ b/learntools/data_cleaning/ex4.py
@@ -2,7 +2,7 @@ from learntools.core import *
 
 import pandas as pd
 import numpy as np
-import chardet
+import charset_normalizer
 import os
 np.random.seed(0)
 

--- a/learntools/data_cleaning/ex5.py
+++ b/learntools/data_cleaning/ex5.py
@@ -4,7 +4,7 @@ import pandas as pd
 import numpy as np
 import fuzzywuzzy
 from fuzzywuzzy import process
-import chardet
+import charset_normalizer
 
 #-----
 

--- a/notebooks/data_cleaning/raw/ex4.ipynb
+++ b/notebooks/data_cleaning/raw/ex4.ipynb
@@ -43,7 +43,7 @@
     "import numpy as np\n",
     "\n",
     "# helpful character encoding module\n",
-    "import chardet\n",
+    "import charset_normalizer\n",
     "\n",
     "# set seed for reproducibility\n",
     "np.random.seed(0)"
@@ -164,7 +164,7 @@
     "#%%RM_IF(PROD)%%\n",
     "# look at the first ten thousand bytes to guess the character encoding\n",
     "with open(\"../input/fatal-police-shootings-in-the-us/PoliceKillingsUS.csv\", 'rb') as rawdata:\n",
-    "    result = chardet.detect(rawdata.read(100000))\n",
+    "    result = charset_normalizer.detect(rawdata.read(100000))\n",
     "\n",
     "# check what the character encoding might be\n",
     "print(result)"
@@ -179,7 +179,7 @@
     "#%%RM_IF(PROD)%%\n",
     "# look at the first ten thousand bytes to guess the character encoding\n",
     "with open(\"../input/fatal-police-shootings-in-the-us/PoliceKillingsUS.csv\", 'rb') as rawdata:\n",
-    "    result = chardet.detect(rawdata.read(10000))\n",
+    "    result = charset_normalizer.detect(rawdata.read(10000))\n",
     "\n",
     "# check what the character encoding might be\n",
     "print(result)"

--- a/notebooks/data_cleaning/raw/ex5.ipynb
+++ b/notebooks/data_cleaning/raw/ex5.ipynb
@@ -45,7 +45,7 @@
     "# helpful modules\n",
     "import fuzzywuzzy\n",
     "from fuzzywuzzy import process\n",
-    "import chardet\n",
+    "import charset_normalizer\n",
     "\n",
     "# read in all our data\n",
     "professors = pd.read_csv(\"../input/pakistan-intellectual-capital/pakistan_intellectual_capital.csv\")\n",

--- a/notebooks/data_cleaning/raw/tut4.ipynb
+++ b/notebooks/data_cleaning/raw/tut4.ipynb
@@ -29,7 +29,7 @@
     "import numpy as np\n",
     "\n",
     "# helpful character encoding module\n",
-    "import chardet\n",
+    "import charset_normalizer\n",
     "\n",
     "# set seed for reproducibility\n",
     "np.random.seed(0)"
@@ -192,10 +192,11 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Notice that we get the same `UnicodeDecodeError` we got when we tried to decode UTF-8 bytes as if they were ASCII! This tells us that this file isn't actually UTF-8. We don't know what encoding it actually *is* though. One way to figure it out is to try and test a bunch of different character encodings and see if any of them work. A better way, though, is to use the chardet module to try and automatically guess what the right encoding is. It's not 100% guaranteed to be right, but it's usually faster than just trying to guess.\n",
+    "Notice that we get the same `UnicodeDecodeError` we got when we tried to decode UTF-8 bytes as if they were ASCII! This tells us that this file isn't actually UTF-8. We don't know what encoding it actually *is* though. One way to figure it out is to try and test a bunch of different character encodings and see if any of them work. A better way, though, is to use the charset_normalizer module to try and automatically guess what the right encoding is. It's not 100% guaranteed to be right, but it's usually faster than just trying to guess.\n",
     "\n",
     "I'm going to just look at the first ten thousand bytes of this file. This is usually enough for a good guess about what the encoding is and is much faster than trying to look at the whole file. (Especially with a  large file this can be very slow.) Another reason to just look at the first part of the file is that  we can see by looking at the error message that the first problem is the 11th character. So we probably only need to look at the first little bit of the file to figure out what's going on."
    ]
@@ -208,17 +209,18 @@
    "source": [
     "# look at the first ten thousand bytes to guess the character encoding\n",
     "with open(\"../input/kickstarter-projects/ks-projects-201801.csv\", 'rb') as rawdata:\n",
-    "    result = chardet.detect(rawdata.read(10000))\n",
+    "    result = charset_normalizer.detect(rawdata.read(10000))\n",
     "\n",
     "# check what the character encoding might be\n",
     "print(result)"
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "So chardet is 73%  confidence that the right encoding is \"Windows-1252\". Let's see if that's correct:"
+    "So charset_normalizer is 73%  confidence that the right encoding is \"Windows-1252\". Let's see if that's correct:"
    ]
   },
   {
@@ -227,7 +229,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# read in the file with the encoding detected by chardet\n",
+    "# read in the file with the encoding detected by charset_normalizer\n",
     "kickstarter_2016 = pd.read_csv(\"../input/kickstarter-projects/ks-projects-201612.csv\", encoding='Windows-1252')\n",
     "\n",
     "# look at the first few lines\n",
@@ -235,12 +237,13 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Yep, looks like chardet was right! The file reads in with no problem (although we do get a warning about datatypes) and when we look at the first few rows it seems to be fine. \n",
+    "Yep, looks like charset_normalizer was right! The file reads in with no problem (although we do get a warning about datatypes) and when we look at the first few rows it seems to be fine. \n",
     "\n",
-    "> **What if the encoding chardet guesses isn't right?** Since chardet is basically just a fancy guesser, sometimes it will guess the wrong encoding. One thing you can try is looking at more or less of the file and seeing if you get a different result and then try that.\n",
+    "> **What if the encoding charset_normalizer guesses isn't right?** Since charset_normalizer is basically just a fancy guesser, sometimes it will guess the wrong encoding. One thing you can try is looking at more or less of the file and seeing if you get a different result and then try that.\n",
     "\n",
     "# Saving your files with UTF-8 encoding\n",
     "\n",

--- a/notebooks/data_cleaning/raw/tut5.ipynb
+++ b/notebooks/data_cleaning/raw/tut5.ipynb
@@ -31,7 +31,7 @@
     "# helpful modules\n",
     "import fuzzywuzzy\n",
     "from fuzzywuzzy import process\n",
-    "import chardet\n",
+    "import charset_normalizer\n",
     "\n",
     "# read in all our data\n",
     "professors = pd.read_csv(\"../input/pakistan-intellectual-capital/pakistan_intellectual_capital.csv\")\n",


### PR DESCRIPTION
- `chardet` will be removed at our next image release.
- `charset_normalizer` is a more accurate & faster than `chardet` and is a
drop-in replacement: https://pypi.org/project/charset-normalizer/