### PR TITLE
fix: replace shade with fill

### DIFF
--- a/learntools/data_viz_to_coder/ex5.py
+++ b/learntools/data_viz_to_coder/ex5.py
@@ -75,12 +75,12 @@ class PlotThreshold(CodingProblem):
              "malignant, use `hue=`.  Set `shade=True`.")
     _solution = CS(
 """# KDE plots for benign and malignant tumors
-sns.kdeplot(data=cancer_data, x='Radius (worst)', hue='Diagnosis', shade=True)
+sns.kdeplot(data=cancer_data, x='Radius (worst)', hue='Diagnosis', fill=True)
 """)
 
     def solution_plot(self):
         self._view.solution()
-        sns.kdeplot(data=df, x='Radius (worst)', hue='Diagnosis', shade=True)
+        sns.kdeplot(data=df, x='Radius (worst)', hue='Diagnosis', fill=True)
     
     def check(self, passed_plt):
         assert len(passed_plt.figure(1).axes) > 0, \

--- a/notebooks/data_viz_to_coder/raw/ex5.ipynb
+++ b/notebooks/data_viz_to_coder/raw/ex5.ipynb
@@ -301,7 +301,7 @@
    "outputs": [],
    "source": [
     "#%%RM_IF(PROD)%%\n",
-    "sns.kdeplot(data=cancer_data, x='Radius (worst)', hue='Diagnosis', shade=True)\n",
+    "sns.kdeplot(data=cancer_data, x='Radius (worst)', hue='Diagnosis', fill=True)\n",
     "step_4.a.assert_check_passed()"
    ]
   },
@@ -312,7 +312,7 @@
    "outputs": [],
    "source": [
     "#%%RM_IF(PROD)%%\n",
-    "#sns.kdeplot(data=cancer_b_data['Radius (worst)'], shade=True, label=\"Benign\")\n",
+    "#sns.kdeplot(data=cancer_b_data['Radius (worst)'], fill=True, label=\"Benign\")\n",
     "#step_4.a.assert_check_failed()"
    ]
   },

--- a/notebooks/data_viz_to_coder/raw/tut5.ipynb
+++ b/notebooks/data_viz_to_coder/raw/tut5.ipynb
@@ -170,7 +170,7 @@
    "outputs": [],
    "source": [
     "# KDE plots for each species\n",
-    "sns.kdeplot(data=iris_data, x='Petal Length (cm)', hue='Species', shade=True)\n",
+    "sns.kdeplot(data=iris_data, x='Petal Length (cm)', hue='Species', fill=True)\n",
     "\n",
     "# Add title\n",
     "plt.title(\"Distribution of Petal Lengths, by Species\")"


### PR DESCRIPTION
```
# KDE plots for benign and malignant tumors
sns.kdeplot(data=cancer_data, x='Radius (worst)', hue='Diagnosis', shade=True)
```
`shade` is now deprecated in favor of `fill`
This will become an error in seaborn v0.14.0
so I just update the code.