### PR TITLE
Update tut_4.ipynb

### DIFF
--- a/notebooks/pandas/raw/tut_4.ipynb
+++ b/notebooks/pandas/raw/tut_4.ipynb
@@ -38,7 +38,7 @@
    },
    "outputs": [],
    "source": [
-    "reviews.price.dtype"
+    "reviews.price.dtype # or reviews.price.dtypes can also be used on a Series"
    ]
   },
   {


### PR DESCRIPTION
Just adding one more way of grabbing the dtype of a Series.  
Both `dtype` and `dtypes` can be used.
Conclusion:
Data Structure  |  Property to get the dtype |  Return type   
-----------------|------------------------------|------------------
Series               |  dtype, dtypes                    |  numpy.dtype[]
DataFrame       |  dtypes                               |  Series