### PR TITLE
Fix image links

### DIFF
--- a/notebooks/intro_to_programming/raw/ex4.ipynb
+++ b/notebooks/intro_to_programming/raw/ex4.ipynb
@@ -533,7 +533,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The next code cell demonstrates how to use `get_labels()` to get the warning labels that the food item should contain.  We begin with [bologna](https://world.openfoodfacts.org/product/4099100179378/bologna).  Here is [an image](https://storage.googleapis.com/kaggle-media/learn/images/Cfcx72e) with all of the nutritional information.  Note that for this food,\n",
+    "The next code cell demonstrates how to use `get_labels()` to get the warning labels that the food item should contain.  We begin with [bologna](https://world.openfoodfacts.org/product/4099100179378/bologna).  Here is [an image](https://storage.googleapis.com/kaggle-media/learn/images/Cfcx72e.png) with all of the nutritional information.  Note that for this food,\n",
     "- `food_type = \"solid\"` (because bologna is a solid and not a liquid)\n",
     "- `serving_size = 32` (the serving size is 32 grams)\n",
     "- `calories_per_serving = 110` (there are 110 calories per serving)\n",
@@ -573,7 +573,7 @@
     "\n",
     "In general, as you continue coding in Python, you will often be running code that other people have written.  This is common practice for advanced programmers.\n",
     "\n",
-    "In the next code cell, fill in the values for [this cereal](https://world.openfoodfacts.org/product/7501008023624/zucaritas-kellogg-s).  Here is [an image](https://storage.googleapis.com/kaggle-media/learn/images/MUxzHVU) with all of the nutritional information.\n",
+    "In the next code cell, fill in the values for [this cereal](https://world.openfoodfacts.org/product/7501008023624/zucaritas-kellogg-s).  Here is [an image](https://storage.googleapis.com/kaggle-media/learn/images/MUxzHVU.png) with all of the nutritional information.\n",
     "\n",
     "**Note**: running the line of code below as-is will return an error.  You have to fill in the nutritional values first."
    ]
@@ -601,7 +601,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Next, try [these mozzarella sticks](https://world-es.openfoodfacts.org/producto/0062325540104/mozzarella-cheese-sticks).  Here is [an image](https://storage.googleapis.com/kaggle-media/learn/images/rcdB7VH) with all of the nutritional information."
+    "Next, try [these mozzarella sticks](https://world-es.openfoodfacts.org/producto/0062325540104/mozzarella-cheese-sticks).  Here is [an image](https://storage.googleapis.com/kaggle-media/learn/images/rcdB7VH.png) with all of the nutritional information."
    ]
   },
   {
@@ -624,12 +624,13 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
     "Feel free to skip to the end of the notebook now and run `q5.check()` to complete the exercise.  If you want to try more foods, \n",
-    "- try [these cookies](https://world.openfoodfacts.org/product/0069700118545/biscuits-au-sucre-pretraches).  Here is [an image](https://storage.googleapis.com/kaggle-media/learn/images/2Bc271o) with all of the nutritional information.\n",
-    "- try [this soda](https://world-es.openfoodfacts.org/producto/0078000113464/orange-soda-sunkist).  Here is [an image](https://storage.googleapis.com/kaggle-media/learn/images/RsBYa8E) with all of the nutritional information.\n",
+    "- try [these cookies](https://world.openfoodfacts.org/product/0069700118545/biscuits-au-sucre-pretraches).  Here is [an image](https://storage.googleapis.com/kaggle-media/learn/images/2Bc271o.png) with all of the nutritional information.\n",
+    "- try [this soda](https://world-es.openfoodfacts.org/producto/0078000113464/orange-soda-sunkist).  Here is [an image](https://storage.googleapis.com/kaggle-media/learn/images/RsBYa8E.png) with all of the nutritional information.\n",
     "\n",
     "Use the two code cells below for this."
    ]


### PR DESCRIPTION
Intro to programming Lesson 4 had some missing image files. This change fixes the URLs in the exercise so that they point to the pngs. Bug: 289537275