### PR TITLE
Fix utils#plot_periodogram

### DIFF
--- a/learntools/time_series/ex3.py
+++ b/learntools/time_series/ex3.py
@@ -14,7 +14,7 @@ class Q2(CodingProblem):  # Create seasonal features
     def check(self, dp, X):
         from statsmodels.tsa.deterministic import (CalendarFourier,
                                                    DeterministicProcess)
-        y = load_average_sales()['2017']
+        y = load_average_sales().loc['2017']
         fourier = CalendarFourier(freq='M', order=4)
         dp = DeterministicProcess(
             index=y.index,

--- a/learntools/time_series/ex4.py
+++ b/learntools/time_series/ex4.py
@@ -1,5 +1,5 @@
 from learntools.core import *
-from learntools.time_series.checking_utils import load_store_sales, load_family_sales
+from learntools.time_series.checking_utils import load_family_sales
 from learntools.time_series.utils import make_lags, make_leads
 
 

--- a/learntools/time_series/utils.py
+++ b/learntools/time_series/utils.py
@@ -40,7 +40,7 @@ def seasonal_plot(X, y, period, freq, ax=None):
 
 def plot_periodogram(ts, detrend='linear', ax=None):
     from scipy.signal import periodogram
-    fs = pd.Timedelta("1Y") / pd.Timedelta("1D")
+    fs = pd.Timedelta("365D") / pd.Timedelta("1D")
     freqencies, spectrum = periodogram(
         ts,
         fs=fs,

--- a/notebooks/feature_engineering_new/raw/tut_bonus.ipynb
+++ b/notebooks/feature_engineering_new/raw/tut_bonus.ipynb
@@ -217,7 +217,7 @@
     "        df[name] = df[name].astype(\"category\")\n",
     "        # Add a None category for missing values\n",
     "        if \"None\" not in df[name].cat.categories:\n",
-    "            df[name].cat.add_categories(\"None\", inplace=True)\n",
+    "            df[name] = df[name].cat.add_categories(\"None\")\n",
     "    # Ordinal categories\n",
     "    for name, levels in ordered_levels.items():\n",
     "        df[name] = df[name].astype(CategoricalDtype(levels,\n",
@@ -707,7 +707,7 @@
    "source": [
     "def corrplot(df, method=\"pearson\", annot=True, **kwargs):\n",
     "    sns.clustermap(\n",
-    "        df.corr(method),\n",
+    "        df.corr(method, numeric_only=True),\n",
     "        vmin=-1.0,\n",
     "        vmax=1.0,\n",
     "        cmap=\"icefire\",\n",

--- a/notebooks/time_series/raw/tut3.ipynb
+++ b/notebooks/time_series/raw/tut3.ipynb
@@ -219,7 +219,7 @@
     "\n",
     "def plot_periodogram(ts, detrend='linear', ax=None):\n",
     "    from scipy.signal import periodogram\n",
-    "    fs = pd.Timedelta(\"1Y\") / pd.Timedelta(\"1D\")\n",
+    "    fs = pd.Timedelta(\"365D\") / pd.Timedelta(\"1D\")\n",
     "    freqencies, spectrum = periodogram(\n",
     "        ts,\n",
     "        fs=fs,\n",


### PR DESCRIPTION
Following pandas upgrade, support for ambiguous timedelta such as `1M` and `1Y` have been dropped.