### PR TITLE
Rename OneHotEncoder option `sparse` to `sparse_output`

### DIFF
--- a/learntools/ml_intermediate/ex3.py
+++ b/learntools/ml_intermediate/ex3.py
@@ -125,7 +125,7 @@ class OneHot(CodingProblem):
              "`X_valid[low_cardinality_cols]`, respectively.")
     _solution = CS(
 """# Apply one-hot encoder to each column with categorical data
-OH_encoder = OneHotEncoder(handle_unknown='ignore', sparse=False)
+OH_encoder = OneHotEncoder(handle_unknown='ignore', sparse_output=False)
 OH_cols_train = pd.DataFrame(OH_encoder.fit_transform(X_train[low_cardinality_cols]))
 OH_cols_valid = pd.DataFrame(OH_encoder.transform(X_valid[low_cardinality_cols]))
 

--- a/learntools/time_series/ex3.py
+++ b/learntools/time_series/ex3.py
@@ -118,7 +118,7 @@ In scikit-learn, your solution would look like:
 ```python
 from sklearn.preprocessing import OneHotEncoder
 
-ohe = OneHotEncoder(sparse=False)
+ohe = OneHotEncoder(sparse_output=False)
 
 X_holidays = pd.DataFrame(
     ____,
@@ -134,7 +134,7 @@ X2 = X.join(X_holidays, on='date').fillna(0.0)
 # Scikit-learn solution
 from sklearn.preprocessing import OneHotEncoder
 
-ohe = OneHotEncoder(sparse=False)
+ohe = OneHotEncoder(sparse_output=False)
 
 X_holidays = pd.DataFrame(
     ohe.fit_transform(holidays),

--- a/notebooks/deep_learning_intro/raw/ex3.ipynb
+++ b/notebooks/deep_learning_intro/raw/ex3.ipynb
@@ -63,7 +63,7 @@
     "preprocessor = make_column_transformer(\n",
     "    (StandardScaler(),\n",
     "     make_column_selector(dtype_include=np.number)),\n",
-    "    (OneHotEncoder(sparse=False),\n",
+    "    (OneHotEncoder(sparse_output=False),\n",
     "     make_column_selector(dtype_include=object)),\n",
     ")\n",
     "\n",

--- a/notebooks/ml_intermediate/raw/ex3.ipynb
+++ b/notebooks/ml_intermediate/raw/ex3.ipynb
@@ -538,7 +538,7 @@
    "source": [
     "#%%RM_IF(PROD)%%\n",
     "# Apply one-hot encoder to each column with categorical data\n",
-    "OH_encoder = OneHotEncoder(handle_unknown='ignore', sparse=False)\n",
+    "OH_encoder = OneHotEncoder(handle_unknown='ignore', sparse_output=False)\n",
     "OH_cols_train = pd.DataFrame(OH_encoder.fit_transform(X_train[low_cardinality_cols]))\n",
     "OH_cols_valid = pd.DataFrame(OH_encoder.transform(X_valid[low_cardinality_cols]))\n",
     "\n",

--- a/notebooks/ml_intermediate/raw/tut3.ipynb
+++ b/notebooks/ml_intermediate/raw/tut3.ipynb
@@ -224,7 +224,7 @@
     "\n",
     "We use the [`OneHotEncoder`](https://scikit-learn.org/stable/modules/generated/sklearn.preprocessing.OneHotEncoder.html) class from scikit-learn to get one-hot encodings.  There are a number of parameters that can be used to customize its behavior.  \n",
     "- We set `handle_unknown='ignore'` to avoid errors when the validation data contains classes that aren't represented in the training data, and\n",
-    "- setting `sparse=False` ensures that the encoded columns are returned as a numpy array (instead of a sparse matrix).\n",
+    "- setting `sparse_output=False` ensures that the encoded columns are returned as a numpy array (instead of a sparse matrix).\n",
     "\n",
     "To use the encoder, we supply only the categorical columns that we want to be one-hot encoded.  For instance, to encode the training data, we supply `X_train[object_cols]`. (`object_cols` in the code cell below is a list of the column names with categorical data, and so `X_train[object_cols]` contains all of the categorical data in the training set.)"
    ]
@@ -238,7 +238,7 @@
     "from sklearn.preprocessing import OneHotEncoder\n",
     "\n",
     "# Apply one-hot encoder to each column with categorical data\n",
-    "OH_encoder = OneHotEncoder(handle_unknown='ignore', sparse=False)\n",
+    "OH_encoder = OneHotEncoder(handle_unknown='ignore', sparse_output=False)\n",
     "OH_cols_train = pd.DataFrame(OH_encoder.fit_transform(X_train[object_cols]))\n",
     "OH_cols_valid = pd.DataFrame(OH_encoder.transform(X_valid[object_cols]))\n",
     "\n",

--- a/notebooks/time_series/raw/ex3.ipynb
+++ b/notebooks/time_series/raw/ex3.ipynb
@@ -513,7 +513,7 @@
     "# Scikit-learn solution\n",
     "from sklearn.preprocessing import OneHotEncoder\n",
     "\n",
-    "ohe = OneHotEncoder(sparse=False)\n",
+    "ohe = OneHotEncoder(sparse_output=False)\n",
     "\n",
     "X_holidays = pd.DataFrame(\n",
     "    ohe.fit_transform(holidays),\n",


### PR DESCRIPTION
While doing the exercise "Categorical Variables" in the "Intermediate Machine Learning" course, I got a `FutureWarning`:
```
/opt/conda/lib/python3.10/site-packages/sklearn/preprocessing/_encoders.py:868: FutureWarning: `sparse` was renamed to `sparse_output` in version 1.2 and will be removed in 1.4. `sparse_output` is ignored unless you leave `sparse` to its default value.
```

Here is the fix across all the project.