### PR TITLE
SQL tutorial ex3 fixes

### DIFF
--- a/learntools/sql/ex3.py
+++ b/learntools/sql/ex3.py
@@ -8,8 +8,8 @@ client = bigquery.Client()
 
 # (1) ProlificCommenters
 prolific_commenters_query = """
-                            SELECT author, COUNT(id) AS NumPosts
-                            FROM `bigquery-public-data.hacker_news.comments`
+                            SELECT `by` AS author, COUNT(id) AS NumPosts
+                            FROM `bigquery-public-data.hacker_news.full`
                             GROUP BY author
                             HAVING COUNT(id) > 10000
                             """
@@ -19,7 +19,7 @@ prolific_commenters_answer = query_job.to_dataframe()
 # (2) NumDeletedPosts
 deleted_posts_query = """
                       SELECT COUNT(1) AS num_deleted_posts
-                      FROM `bigquery-public-data.hacker_news.comments`
+                      FROM `bigquery-public-data.hacker_news.full`
                       WHERE deleted = True
                       """
 query_job = client.query(deleted_posts_query)
@@ -46,8 +46,8 @@ class ProlificCommenters(CodingProblem):
     _solution = CS(\
 """
 prolific_commenters_query = \"""
-                            SELECT author, COUNT(1) AS NumPosts
-                            FROM `bigquery-public-data.hacker_news.comments`
+                            SELECT `by` AS author, COUNT(1) AS NumPosts
+                            FROM `bigquery-public-data.hacker_news.full`
                             GROUP BY author
                             HAVING COUNT(1) > 10000
                             \"""
@@ -62,7 +62,7 @@ class NumDeletedPosts(EqualityCheckProblem):
 # Query to determine how many posts were deleted
 deleted_posts_query = \"""
                       SELECT COUNT(1) AS num_deleted_posts
-                      FROM `bigquery-public-data.hacker_news.comments`
+                      FROM `bigquery-public-data.hacker_news.full`
                       WHERE deleted = True
                       \"""
                       

--- a/notebooks/sql/raw/ex3.ipynb
+++ b/notebooks/sql/raw/ex3.ipynb
@@ -28,7 +28,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The code cell below fetches the `comments` table from the `hacker_news` dataset.  We also preview the first five rows of the table."
+    "The code cell below fetches the `full` table from the `hacker_news` dataset.  We also preview the first five rows of the table."
    ]
   },
   {
@@ -48,13 +48,13 @@
     "# API request - fetch the dataset\n",
     "dataset = client.get_dataset(dataset_ref)\n",
     "\n",
-    "# Construct a reference to the \"comments\" table\n",
-    "table_ref = dataset_ref.table(\"comments\")\n",
+    "# Construct a reference to the \"full\" table\n",
+    "table_ref = dataset_ref.table(\"full\")\n",
     "\n",
     "# API request - fetch the table\n",
     "table = client.get_table(table_ref)\n",
     "\n",
-    "# Preview the first five lines of the \"comments\" table\n",
+    "# Preview the first five lines of the table\n",
     "client.list_rows(table, max_results=5).to_dataframe()"
    ]
   },
@@ -72,7 +72,7 @@
     "```\n",
     "query = \"\"\"\n",
     "        SELECT parent, COUNT(1) AS NumPosts\n",
-    "        FROM `bigquery-public-data.hacker_news.comments`\n",
+    "        FROM `bigquery-public-data.hacker_news.full`\n",
     "        GROUP BY parent\n",
     "        HAVING COUNT(1) > 10\n",
     "        \"\"\"\n",
@@ -86,7 +86,7 @@
    "outputs": [],
    "source": [
     "# Query to select prolific commenters and post counts\n",
-    "prolific_commenters_query = ____ # Your code goes here\n",
+    "prolific_commenters_query = \"\"\"____\"\"\" # Your code goes here\n",
     "\n",
     "# Set up the query (cancel the query if it would use too much of \n",
     "# your quota, with the limit set to 1 GB)\n",
@@ -125,7 +125,7 @@
    "source": [
     "### 2) Deleted comments\n",
     "\n",
-    "How many comments have been deleted? (If a comment was deleted, the `deleted` column in the comments table will have the value `True`.)"
+    "How many comments have been deleted? (If a comment was deleted, the `deleted` column in the table will have the value `True`.)"
    ]
   },
   {

--- a/notebooks/sql/raw/tut3.ipynb
+++ b/notebooks/sql/raw/tut3.ipynb
@@ -50,7 +50,7 @@
     "\n",
     "Ready to see an example on a real dataset? The Hacker News dataset contains information on stories and comments from the Hacker News social networking site. \n",
     "\n",
-    "We'll work with the `comments` table and begin by printing the first few rows.  (_We have hidden the corresponding code. To take a peek, click on the \"Code\" button below._)"
+    "We'll work with the `full` table and begin by printing the first few rows.  (_We have hidden the corresponding code. To take a peek, click on the \"Code\" button below._)"
    ]
   },
   {
@@ -73,13 +73,13 @@
     "# API request - fetch the dataset\n",
     "dataset = client.get_dataset(dataset_ref)\n",
     "\n",
-    "# Construct a reference to the \"comments\" table\n",
-    "table_ref = dataset_ref.table(\"comments\")\n",
+    "# Construct a reference to the \"full\" table\n",
+    "table_ref = dataset_ref.table(\"full\")\n",
     "\n",
     "# API request - fetch the table\n",
     "table = client.get_table(table_ref)\n",
     "\n",
-    "# Preview the first five lines of the \"comments\" table\n",
+    "# Preview the first five lines of the table\n",
     "client.list_rows(table, max_results=5).to_dataframe()"
    ]
   },
@@ -105,7 +105,7 @@
     "# Query to select comments that received more than 10 replies\n",
     "query_popular = \"\"\"\n",
     "                SELECT parent, COUNT(id)\n",
-    "                FROM `bigquery-public-data.hacker_news.comments`\n",
+    "                FROM `bigquery-public-data.hacker_news.full`\n",
     "                GROUP BY parent\n",
     "                HAVING COUNT(id) > 10\n",
     "                \"\"\""
@@ -160,7 +160,7 @@
     "# Improved version of earlier query, now with aliasing & improved readability\n",
     "query_improved = \"\"\"\n",
     "                 SELECT parent, COUNT(1) AS NumPosts\n",
-    "                 FROM `bigquery-public-data.hacker_news.comments`\n",
+    "                 FROM `bigquery-public-data.hacker_news.full`\n",
     "                 GROUP BY parent\n",
     "                 HAVING COUNT(1) > 10\n",
     "                 \"\"\"\n",
@@ -199,7 +199,7 @@
    "source": [
     "query_good = \"\"\"\n",
     "             SELECT parent, COUNT(id)\n",
-    "             FROM `bigquery-public-data.hacker_news.comments`\n",
+    "             FROM `bigquery-public-data.hacker_news.full`\n",
     "             GROUP BY parent\n",
     "             \"\"\""
    ]
@@ -222,8 +222,8 @@
    "outputs": [],
    "source": [
     "query_bad = \"\"\"\n",
-    "            SELECT author, parent, COUNT(id)\n",
-    "            FROM `bigquery-public-data.hacker_news.comments`\n",
+    "            SELECT `by` AS author, parent, COUNT(id)\n",
+    "            FROM `bigquery-public-data.hacker_news.full`\n",
     "            GROUP BY parent\n",
     "            \"\"\""
    ]
@@ -233,6 +233,8 @@
    "metadata": {},
    "source": [
     "If make this error, you'll get the error message `SELECT list expression references column (column's name) which is neither grouped nor aggregated at`.\n",
+    "\n",
+    "You may notice the `` `by` `` column in this query is surrounded by backticks. This is because **BY** is a reserved keyword used in clauses including **GROUP BY**. In BigQuery reserved keywords used as identifiers must be quoted in backticks to avoid an error. We also make subsequent references to this column more readable by adding an alias to rename it to `author`.\n",
     "\n",
     "# Your turn\n",
     "\n",


### PR DESCRIPTION
I noticed exercise 3 in the intro to SQL tutorial was broken. The tutorial and exercise notebooks still reference the BigQuery public hacker news dataset `comments` table. This dataset has been updated and now only contains one table: `full`. 

The first query in the exercise doesn't work as nicely using the `full` table because one of the columns used is called `by` and needs to be quoted. However this PR attempts to fix the issue by referencing the correct table and adding a note in the tutorial about reserved words. 

Related discussion post on Kaggle:
https://www.kaggle.com/learn/intro-to-sql/discussion/417044#2316394

Copy of the tutorial notebook with proposed changes applied:
https://www.kaggle.com/mmcbex/sql-tutorial-3-updated

Fixes: 
https://github.com/Kaggle/learntools/issues/452

A couple follow up issues related to this one:
- In [tutorial 1](https://www.kaggle.com/code/dansbecker/getting-started-with-sql-and-bigquery), the hacker news dataset is also explored and the missing tables are mentioned. Unfortunately there is a nice diagram that is now outdated. 
- Exercises 1 and 2 in the Intro to SQL course add the hacker news dataset but do not use them. I believe those could be removed by deleting the references in [this file](https://github.com/Kaggle/learntools/blob/master/notebooks/sql/track_meta.py) but maybe out of scope for this PR. 
- An [updated version of the dataset](https://www.kaggle.com/datasets/hacker-news/hacker-news/data) could be published on Kaggle. ~~I will report the dataset as outdated and include a like to this PR for context~~ (my report failed with an internal error 🤷‍♀️).  