### PR TITLE
Enable kernels to be pinned to the original docker image

### DIFF
--- a/notebooks/computer_vision/track_meta.py
+++ b/notebooks/computer_vision/track_meta.py
@@ -24,73 +24,85 @@ notebooks = [
         lesson_idx=0,
         type='tutorial',
         enable_gpu=True,
+        docker_image_pinning_type="original",
     ),
     dict(
         filename="ex1.ipynb",
         lesson_idx=0,
         type='exercise',
         enable_gpu=True,
-        scriptid=10781907
+        scriptid=10781907,
+        docker_image_pinning_type="original",
     ),
     dict(
         filename="tut2.ipynb",
         lesson_idx=1,
         type='tutorial',
+        docker_image_pinning_type="original",
     ),
     dict(
         filename="ex2.ipynb",
         lesson_idx=1,
         type='exercise',
-        scriptid=11989557
+        scriptid=11989557,
+        docker_image_pinning_type="original",
     ),
     dict(
         filename="tut3.ipynb",
         lesson_idx=2,
         type='tutorial',
+        docker_image_pinning_type="original",
     ),
     dict(
         filename="ex3.ipynb",
         lesson_idx=2,
         type='exercise',
-        scriptid=11989559
+        scriptid=11989559,
+        docker_image_pinning_type="original",
     ),
     dict(
         filename="tut4.ipynb",
         lesson_idx=3,
         type='tutorial',
+        docker_image_pinning_type="original",
     ),
     dict(
         filename="ex4.ipynb",
         lesson_idx=3,
         type='exercise',
-        scriptid=12400209
+        scriptid=12400209,
+        docker_image_pinning_type="original",
     ),
     dict(
         filename="tut5.ipynb",
         lesson_idx=4,
         type='tutorial',
         enable_gpu=True,
+        docker_image_pinning_type="original",
     ),
     dict(
         filename="ex5.ipynb",
         lesson_idx=4,
         type='exercise',
         enable_gpu=True,
-        scriptid=11989565
+        scriptid=11989565,
+        docker_image_pinning_type="original",
     ),
     dict(
         filename="tut6.ipynb",
         lesson_idx=5,
         type='tutorial',
         enable_gpu=True,
+        docker_image_pinning_type="original",
     ), 
     dict(
         filename="ex6.ipynb",
         lesson_idx=5,
         type='exercise',
         enable_gpu=True,
-        scriptid=11991328
-    ),  
+        scriptid=11991328,
+        docker_image_pinning_type="original",
+    ),
 ]
 
 for nb in notebooks:

--- a/notebooks/deep_learning/track_meta.py
+++ b/notebooks/deep_learning/track_meta.py
@@ -2,150 +2,165 @@ track = dict(
     author_username='dansbecker',
     course_name='Deep Learning',
     course_url='https://www.kaggle.com/learn/deep-learning',
-    course_forum_url='https://www.kaggle.com/learn-forum/161321'
+    course_forum_url='https://www.kaggle.com/learn-forum/161321',
 )
 
-lessons = [ {'topic': topic_name} for topic_name in
-                    [
-		 	'Intro to Deep Learning and Computer Vision',
-			'Building Models from Convolutions',
-			'TensorFlow programming',
-			'Transfer Learning',
-			'Data Augmentation',
-			'A Deeper Understanding of Deep Learning',
-			'Deep Learning from Scratch',
-			'Dropout and Strides for Larger Models',
-            'Create Your First Submission'
-			]
-            ]
+lessons = [ {'topic': topic_name} for topic_name in [
+        'Intro to Deep Learning and Computer Vision',
+        'Building Models from Convolutions',
+        'TensorFlow programming',
+        'Transfer Learning',
+        'Data Augmentation',
+        'A Deeper Understanding of Deep Learning',
+        'Deep Learning from Scratch',
+        'Dropout and Strides for Larger Models',
+        'Create Your First Submission'
+    ]
+]
 
 notebooks = [
     dict(
         filename='tut1_intro.ipynb',
         lesson_idx=0,
         type='tutorial',
-        ),
+        docker_image_pinning_type="original",
+    ),
     dict(
-	filename='ex1_convolutions.ipynb',
-	lesson_idx=0,
-	type='exercise',
-	scriptid=499266,
-	dataset_sources = ["keras/resnet50"],
-    competition_sources = ["dog-breed-identification"],
-	),
+        filename='ex1_convolutions.ipynb',
+        lesson_idx=0,
+        type='exercise',
+        scriptid=499266,
+        dataset_sources=["keras/resnet50"],
+        competition_sources=["dog-breed-identification"],
+        docker_image_pinning_type="original",
+    ),
     dict(
         filename='tut2_building_models_from_convolutions.ipynb',
         lesson_idx=1,
         type='tutorial',
-        ),
+        docker_image_pinning_type="original",
+    ),
     dict(
         filename='tut3_programming_tf_and_keras.ipynb',
         lesson_idx=2,
         type='tutorial',
-	dataset_sources = ["keras/resnet50"],
-	competition_sources = ["dog-breed-identification"],
+        dataset_sources=["keras/resnet50"],
+        competition_sources=["dog-breed-identification"],
+        docker_image_pinning_type="original",
     ),
     dict(
         filename='ex3_programming_tf_and_keras.ipynb',
         lesson_idx=2,
         type='exercise',
-	enable_gpu=True,
-	scriptid=521452,
-	dataset_sources = [
-	    "alexisbcook/resnet50",
-	    "alexisbcook/vgg16",
-	    "dansbecker/hot-dog-not-hot-dog"
-	  ],
+        enable_gpu=True,
+        scriptid=521452,
+        dataset_sources = [
+            "alexisbcook/resnet50",
+            "alexisbcook/vgg16",
+            "dansbecker/hot-dog-not-hot-dog"
+        ],
+        docker_image_pinning_type="original",
     ),
     dict(
         filename='tut4_transfer_learning.ipynb',
         lesson_idx=3,
         type='tutorial',
-	dataset_sources = [
-	    "keras/resnet50",
-	    "dansbecker/urban-and-rural-photos"
-	  ],
+        dataset_sources = [
+            "keras/resnet50",
+            "dansbecker/urban-and-rural-photos"
+        ],
+        docker_image_pinning_type="original",
     ),
     dict(
         filename='ex4_transfer_learning.ipynb',
         lesson_idx=3,
         type='exercise',
-	scriptid=532365,
-	dataset_sources = [
-	"alexisbcook/resnet50",
-    "dansbecker/dogs-gone-sideways"
-	],
-	enable_gpu=True,
+        scriptid=532365,
+        dataset_sources = [
+            "alexisbcook/resnet50",
+            "dansbecker/dogs-gone-sideways"
+        ],
+        enable_gpu=True,
+        docker_image_pinning_type="original",
     ),
     dict(
         filename='tut5_data_augmentation.ipynb',
         lesson_idx=4,
         type='tutorial',
-	    dataset_sources = [
-	    "keras/resnet50",
-	    "dansbecker/urban-and-rural-photos",
-	  ],
+        dataset_sources = [
+            "keras/resnet50",
+            "dansbecker/urban-and-rural-photos",
+        ],
+        docker_image_pinning_type="original",
     ),
     dict(
         filename='ex5_data_augmentation.ipynb',
         lesson_idx=4,
         type='exercise',
-	    enable_gpu=True,
-	    scriptid=536195,
+        enable_gpu=True,
+        scriptid=536195,
        	dataset_sources = [
-	    "alexisbcook/resnet50",
-	    "dansbecker/dogs-gone-sideways"
-	  ],
-      ),
+            "alexisbcook/resnet50",
+            "dansbecker/dogs-gone-sideways"
+        ],
+        docker_image_pinning_type="original",
+    ),
     dict(
         filename='tut6_deep_understanding.ipynb',
         lesson_idx=5,
         type='tutorial',
-        ),
+        docker_image_pinning_type="original",
+    ),
     dict(filename='tut7_dl_from_scratch.ipynb',
         lesson_idx=6,
         type='tutorial',
-	    dataset_sources = ['zalando-research/fashionmnist'],
-	    competition_sources=['digit-recognizer'],
-        ),
+        dataset_sources=['zalando-research/fashionmnist'],
+        competition_sources=['digit-recognizer'],
+        docker_image_pinning_type="original",
+    ),
     dict(
         filename='ex7_from_scratch.ipynb',
         lesson_idx=6,
-	    enable_gpu=True,
+        enable_gpu=True,
         type='exercise',
         scriptid=574269,
-	    competition_sources=['digit-recognizer'],
-	    dataset_sources = ['zalando-research/fashionmnist'],
-        ),
+        competition_sources=['digit-recognizer'],
+        dataset_sources=['zalando-research/fashionmnist'],
+        docker_image_pinning_type="original",
+    ),
     dict(
         filename='tut8_dropout_and_strides.ipynb',
         lesson_idx=7,
         type='tutorial',
-	    competition_sources=['digit-recognizer'],
-	    dataset_sources = ['zalando-research/fashionmnist'],
-        ),
+        competition_sources=['digit-recognizer'],
+        dataset_sources=['zalando-research/fashionmnist'],
+        docker_image_pinning_type="original",
+    ),
     dict(
         filename='ex8_dropout_strides.ipynb',
         lesson_idx=7,
-	    enable_gpu=True,
+        enable_gpu=True,
         type='exercise',
-	    scriptid=663261,
-	    competition_sources=['digit-recognizer'],
-        dataset_sources = ['zalando-research/fashionmnist'],
-        ),
+        scriptid=663261,
+        competition_sources=['digit-recognizer'],
+        dataset_sources=['zalando-research/fashionmnist'],
+        docker_image_pinning_type="original",
+    ),
     dict(
         filename='tut_tpus.ipynb',
         lesson_idx=8,
         type='tutorial',
         competition_sources=['tpu-getting-started'],
-        enable_internet=True
-        ),
+        enable_internet=True,
+        docker_image_pinning_type="original",
+    ),
     dict(
         filename='ex_tpus.ipynb',
         lesson_idx=8,
         type='exercise',
         scriptid=10204702,
         competition_sources=['tpu-getting-started'],
-        enable_internet=True      
-        )
-    ]
+        enable_internet=True,
+        docker_image_pinning_type="original",
+    )
+]

--- a/notebooks/nb_utils/track_metadata.py
+++ b/notebooks/nb_utils/track_metadata.py
@@ -131,6 +131,7 @@ class Notebook(object):
     def __init__(self, cfg, filename, type, author=None, title=None, lesson=None,
             slug=None, scriptid=1, kernel_sources=(), dataset_sources=(),
             competition_sources=(), keywords=(), enable_gpu=False, enable_internet=None,
+            docker_image_pinning_type=None
             ):
         self.cfg = cfg
         self.filename = filename
@@ -170,6 +171,7 @@ class Notebook(object):
         self.keywords = list(keywords)
         self.enable_gpu = bool(enable_gpu)
         self.enable_internet = enable_internet
+        self.docker_image_pinning_type = docker_image_pinning_type
 
     @staticmethod
     def _topic_to_title(topic):
@@ -221,5 +223,5 @@ class Notebook(object):
                 competition_sources=sorted(self.competition_sources),
                 kernel_sources=sorted(self.kernel_sources),
                 keywords=sorted(self.keywords),
-                docker_image_pinning_type="latest",
+                docker_image_pinning_type="latest" if self.docker_image_pinning_type is None else self.docker_image_pinning_type,
                 )


### PR DESCRIPTION
Also applies original pinning type to the Computer Vision and Deep Learning tracks, which would be broken by the Keras 3 upgrade. These have already been pinned via direct DB update, but this change is needed to make sure that they don't revert back to latest during the next push.

http://b/324889848