### PR TITLE
fixed int array error in learntools SQL ex5 q3

### DIFF
--- a/learntools/sql/ex5.py
+++ b/learntools/sql/ex5.py
@@ -97,8 +97,8 @@ class YearDistrib(CodingProblem):
         assert (len(results) == len(rides_per_year_answer)), ("The results don't look right. Try again.")
         # check 3: one value in particular
         year_to_check = list(rides_per_year_answer["year"])[-1]
-        correct_number = int(rides_per_year_answer.loc[rides_per_year_answer["year"]==year_to_check]["num_trips"].values)
-        submitted_number = int(results.loc[results["year"]==year_to_check]["num_trips"].values)
+        correct_number = rides_per_year_answer.loc[rides_per_year_answer["year"]==year_to_check]["num_trips"].values[0]
+        submitted_number = results.loc[results["year"]==year_to_check]["num_trips"].values[0]
         assert (correct_number == submitted_number), ("The results don't look right. Try again.")
 
     _hint = "Start your query with `SELECT EXTRACT(YEAR FROM trip_start_timestamp) AS year, COUNT(1) AS num_trips`."


### PR DESCRIPTION
The bug was in lines 100 and 101, where the code was trying to call `int()` on a single-element integer list, which returned `TypeError: int() argument must be a string, a bytes-like object or a real number, not 'IntegerArray'`. To fix this, all I did was replace the `int()` function with accessing the first (and only) element with `[0]` for both lines.

I tested this with this code cell in the Kaggle learn notebook for this exercise, which is a modified version of the ex5.py file:
```
from google.cloud import bigquery

from learntools.core import *

# Setup (4.57s on Kaggle)
client = bigquery.Client()

# (3) YearDistrib
rides_per_year_query = """
                       SELECT EXTRACT(YEAR FROM trip_start_timestamp) AS year, 
                              COUNT(1) AS num_trips
                       FROM `bigquery-public-data.chicago_taxi_trips.taxi_trips`
                       GROUP BY year
                       ORDER BY year
                       """
rides_per_year_query_job = client.query(rides_per_year_query)
rides_per_year_answer = rides_per_year_query_job.to_dataframe()


# (3)
def q3_check(results):
    # check 1: column names
    results.columns = [c.lower() for c in results.columns]
    assert ('year' in results.columns), ('Your results should have a `year` column. But your columns are {}.'.format(list(results.columns)))
    assert ('num_trips' in results.columns), ('Your results should have a `num_trips` column. But your columns are {}.'.format(list(results.columns)))
    # check 2: length of dataframe
    assert (len(results) == len(rides_per_year_answer)), ("The results don't look right. Try again.")
    # check 3: one value in particular
    year_to_check = list(rides_per_year_answer["year"])[-1]
    correct_number = rides_per_year_answer.loc[rides_per_year_answer["year"]==year_to_check]["num_trips"].values[0]
    submitted_number = results.loc[results["year"]==year_to_check]["num_trips"].values[0]
    assert (correct_number == submitted_number), ("The results don't look right. Try again.")`
```

...and then this code cell, which ran the `q3_check()` function and did not return any assertion errors:
```
# Your code goes here
rides_per_year_query = """
                       SELECT EXTRACT(YEAR FROM trip_start_timestamp) AS year, 
                              COUNT(1) AS num_trips
                       FROM `bigquery-public-data.chicago_taxi_trips.taxi_trips`
                       GROUP BY year
                       ORDER BY year
                       """

# Set up the query (cancel the query if it would use too much of 
# your quota)
safe_config = bigquery.QueryJobConfig(maximum_bytes_billed=10**10)
rides_per_year_query_job = client.query(rides_per_year_query, job_config=safe_config)

# API request - run the query, and return a pandas DataFrame
rides_per_year_result = rides_per_year_query_job.to_dataframe()

# View results
print(rides_per_year_result)

q3_check(rides_per_year_result)
```

I haven't considered if any checks are required if the resulting integer array ends up longer than a single element and that single element coincidentally is the correct number. It may be something to look into.