### PR TITLE
Fixes for type errors and NA errors in Intro to SQL and Advanced SQL courses

### DIFF
--- a/learntools/sql/ex5.py
+++ b/learntools/sql/ex5.py
@@ -99,7 +99,7 @@ class YearDistrib(CodingProblem):
         year_to_check = rides_per_year_answer["year"].iloc[-1]
         correct_number = rides_per_year_answer.loc[rides_per_year_answer["year"] == year_to_check, "num_trips"].iloc[0]
         submitted_number = results.loc[results["year"] == year_to_check, "num_trips"].iloc[0]
-        assert(correct_number == submitted_number), ("The results don't look right. Try again.")
+        assert correct_number == submitted_number, "The results don't look right. Try again."
         
     _hint = "Start your query with `SELECT EXTRACT(YEAR FROM trip_start_timestamp) AS year, COUNT(1) AS num_trips`."
     _solution = CS(

--- a/learntools/sql/ex5.py
+++ b/learntools/sql/ex5.py
@@ -97,11 +97,9 @@ class YearDistrib(CodingProblem):
         assert (len(results) == len(rides_per_year_answer)), ("The results don't look right. Try again.")
         # check 3: one value in particular
         year_to_check = rides_per_year_answer["year"].iloc[-1]
-        correct_number = rides_per_year_answer.loc[rides_per_year_answer["year"] == year_to_check, 
-             "num_trips"].iloc[0]
-        submitted_number = results.loc[results["year"] == year_to_check, 
-             "num_trips"].iloc[0]
-        assert(correct_number == submitted_number)
+        correct_number = rides_per_year_answer.loc[rides_per_year_answer["year"] == year_to_check, "num_trips"].iloc[0]
+        submitted_number = results.loc[results["year"] == year_to_check, "num_trips"].iloc[0]
+        assert(correct_number == submitted_number), ("The results don't look right. Try again.")
         
     _hint = "Start your query with `SELECT EXTRACT(YEAR FROM trip_start_timestamp) AS year, COUNT(1) AS num_trips`."
     _solution = CS(

--- a/learntools/sql/ex5.py
+++ b/learntools/sql/ex5.py
@@ -96,11 +96,13 @@ class YearDistrib(CodingProblem):
         # check 2: length of dataframe
         assert (len(results) == len(rides_per_year_answer)), ("The results don't look right. Try again.")
         # check 3: one value in particular
-        year_to_check = list(rides_per_year_answer["year"])[-1]
-        correct_number = int(rides_per_year_answer.loc[rides_per_year_answer["year"]==year_to_check]["num_trips"].values)
-        submitted_number = int(results.loc[results["year"]==year_to_check]["num_trips"].values)
-        assert (correct_number == submitted_number), ("The results don't look right. Try again.")
-
+        year_to_check = rides_per_year_answer["year"].iloc[-1]
+        correct_number = rides_per_year_answer.loc[rides_per_year_answer["year"] == year_to_check, 
+             "num_trips"].iloc[0]
+        submitted_number = results.loc[results["year"] == year_to_check, 
+             "num_trips"].iloc[0]
+        assert(correct_number == submitted_number)
+        
     _hint = "Start your query with `SELECT EXTRACT(YEAR FROM trip_start_timestamp) AS year, COUNT(1) AS num_trips`."
     _solution = CS(
 """

--- a/learntools/sql/ex6.py
+++ b/learntools/sql/ex6.py
@@ -193,7 +193,7 @@ bigquery_experts_results = bigquery_experts_query_job.to_dataframe()
         # check 3: correct user IDs
         correct_ids = bigquery_experts_answer.loc[bigquery_experts_answer.user_id.notna(), "user_id"].unique()
         submitted_ids = results.loc[results.user_id.notna(), "user_id"].unique()
-        assert(np.array_equal(correct_ids, submitted_ids))
+        assert(np.array_equal(correct_ids, submitted_ids)), ), ('You seem to have the wrong values in the `user_id` column.')
         # check 4: check one value from other column
         first_id = list(bigquery_experts_answer["user_id"])[0]
         correct_num = int(bigquery_experts_answer[bigquery_experts_answer["user_id"] == first_id]["number_of_answers"])

--- a/learntools/sql/ex6.py
+++ b/learntools/sql/ex6.py
@@ -191,9 +191,9 @@ bigquery_experts_results = bigquery_experts_query_job.to_dataframe()
         assert ('user_id' in results.columns), ('You do not have a `user_id` column in your results.')
         assert ('number_of_answers' in results.columns), ('You do not have a `number_of_answers` column in your results.')
         # check 3: correct user IDs
-        correct_ids = set([int(i) for i in bigquery_experts_answer.user_id.values if not np.isnan(i)])
-        submitted_ids = set([int(i) for i in results.user_id.values if not np.isnan(i)])
-        assert (correct_ids == submitted_ids), ('You seem to have the wrong values in the `user_id` column.')
+        correct_ids = bigquery_experts_answer.loc[bigquery_experts_answer.user_id.notna(), "user_id"].unique()
+        submitted_ids = results.loc[results.user_id.notna(), "user_id"].unique()
+        assert(np.array_equal(correct_ids, submitted_ids))
         # check 4: check one value from other column
         first_id = list(bigquery_experts_answer["user_id"])[0]
         correct_num = int(bigquery_experts_answer[bigquery_experts_answer["user_id"] == first_id]["number_of_answers"])

--- a/learntools/sql/ex6.py
+++ b/learntools/sql/ex6.py
@@ -193,7 +193,7 @@ bigquery_experts_results = bigquery_experts_query_job.to_dataframe()
         # check 3: correct user IDs
         correct_ids = bigquery_experts_answer.loc[bigquery_experts_answer.user_id.notna(), "user_id"].unique()
         submitted_ids = results.loc[results.user_id.notna(), "user_id"].unique()
-        assert(np.array_equal(correct_ids, submitted_ids)), ), ('You seem to have the wrong values in the `user_id` column.')
+        assert np.array_equal(correct_ids, submitted_ids), 'You seem to have the wrong values in the `user_id` column.'
         # check 4: check one value from other column
         first_id = list(bigquery_experts_answer["user_id"])[0]
         correct_num = int(bigquery_experts_answer[bigquery_experts_answer["user_id"] == first_id]["number_of_answers"])

--- a/learntools/sql_advanced/ex1.py
+++ b/learntools/sql_advanced/ex1.py
@@ -79,11 +79,11 @@ class CorrectQuery(CodingProblem):
                                                        "%d rows, but you have %d rows." % (len(correct_answer), len(results)))
         # check 2: calculated values
         # correct result
-        correct_list = [i for i in list(correct_answer["time_to_answer"]) if not math.isnan(i)]
-        correct_number = int(sum(correct_list)/len(correct_list))
+        correct_list = correct_answwer.loc[correct_answer["time_to_answer"].notna(), "time_to_answer"]
+        correct_number = correct_list.sum()/len(correct_list))
         # submitted value
-        submitted_list = [i for i in list(results["time_to_answer"]) if not math.isnan(i)]
-        submitted_number = int(sum(submitted_list)/len(submitted_list))
+        submitted_list = results.loc[results["time_to_answer"].notna(), "time_to_answer"]
+        submitted_number = submitted_list.sum()/len(submitted_list))
         assert (int(submitted_number)==int(correct_number)), ("The results don't look right. Please make sure that the part of the query "
                                                               "that calculates the values in the `time_to_answer` column is unmodified.")
     

--- a/learntools/sql_advanced/ex1.py
+++ b/learntools/sql_advanced/ex1.py
@@ -79,7 +79,7 @@ class CorrectQuery(CodingProblem):
                                                        "%d rows, but you have %d rows." % (len(correct_answer), len(results)))
         # check 2: calculated values
         # correct result
-        correct_list = correct_result.loc[correct_result["time_to_answer"].notna(), "time_to_answer"]
+        correct_list = correct_answer.loc[correct_answer["time_to_answer"].notna(), "time_to_answer"]
         correct_number = correct_list.sum()/len(correct_list)
         # submitted value
         submitted_list = results.loc[results["time_to_answer"].notna(), "time_to_answer"]

--- a/learntools/sql_advanced/ex1.py
+++ b/learntools/sql_advanced/ex1.py
@@ -80,10 +80,10 @@ class CorrectQuery(CodingProblem):
         # check 2: calculated values
         # correct result
         correct_list = correct_answwer.loc[correct_answer["time_to_answer"].notna(), "time_to_answer"]
-        correct_number = correct_list.sum()/len(correct_list))
+        correct_number = correct_list.sum()/len(correct_list)
         # submitted value
         submitted_list = results.loc[results["time_to_answer"].notna(), "time_to_answer"]
-        submitted_number = submitted_list.sum()/len(submitted_list))
+        submitted_number = submitted_list.sum()/len(submitted_list)
         assert (int(submitted_number)==int(correct_number)), ("The results don't look right. Please make sure that the part of the query "
                                                               "that calculates the values in the `time_to_answer` column is unmodified.")
     

--- a/learntools/sql_advanced/ex1.py
+++ b/learntools/sql_advanced/ex1.py
@@ -84,7 +84,7 @@ class CorrectQuery(CodingProblem):
         # submitted value
         submitted_list = results.loc[results["time_to_answer"].notna(), "time_to_answer"]
         submitted_number = submitted_list.sum()/len(submitted_list)
-        assert (int(submitted_number)==int(correct_number)), ("The results don't look right. Please make sure that the part of the query "
+        assert int(submitted_number) == int(correct_number), ("The results don't look right. Please make sure that the part of the query "
                                                               "that calculates the values in the `time_to_answer` column is unmodified.")
     
     _solution = CS(\

--- a/learntools/sql_advanced/ex1.py
+++ b/learntools/sql_advanced/ex1.py
@@ -79,7 +79,7 @@ class CorrectQuery(CodingProblem):
                                                        "%d rows, but you have %d rows." % (len(correct_answer), len(results)))
         # check 2: calculated values
         # correct result
-        correct_list = correct_answwer.loc[correct_answer["time_to_answer"].notna(), "time_to_answer"]
+        correct_list = correct_result.loc[correct_result["time_to_answer"].notna(), "time_to_answer"]
         correct_number = correct_list.sum()/len(correct_list)
         # submitted value
         submitted_list = results.loc[results["time_to_answer"].notna(), "time_to_answer"]

--- a/learntools/sql_advanced/ex2.py
+++ b/learntools/sql_advanced/ex2.py
@@ -173,12 +173,12 @@ class BreakTime(CodingProblem):
         # check 3: check values, length of dataframe
         assert (len(results)==len(break_time_answer)), ("Your answer does not have the correct number of rows.")
         # check 4: specific number
-        id_to_check = list(break_time_answer["taxi_id"])[0]
-        correct_ans = [int(i) for i in list(break_time_answer.loc[break_time_answer["taxi_id"] == id_to_check]["prev_break"]) if math.isnan(i)==False]
-        submitted_ans = [int(i) for i in list(results.loc[results["taxi_id"] == id_to_check]["prev_break"]) if math.isnan(i)==False]
+        id_to_check = break_time_answer["taxi_id"].iloc[0]
+        correct_ans = break_time_answer.loc[break_time_answer"taxi_id"].eq(id_to_check) & break_time_answer["prev_break"].notna(), "prev_break"]
+        submitted_ans = results.loc[results["taxi_id"].eq(id_to_check) & results["prev_break"].notna(), "prev_break"]
         if len(correct_ans) > 0:
-            assert (min(correct_ans)==min(submitted_ans)), ("The results don't look right. Try again.")
-            assert (max(correct_ans)==max(submitted_ans)), ("The results don't look right. Try again.")
+            assert (correct_ans.min() == submitted_ans.min()), ("The results don't look right. Try again.")
+            assert (correct_ans.max() == submitted_ans.max()), ("The results don't look right. Try again.")
 
     _solution = CS( \
 """

--- a/learntools/sql_advanced/ex2.py
+++ b/learntools/sql_advanced/ex2.py
@@ -174,7 +174,7 @@ class BreakTime(CodingProblem):
         assert (len(results)==len(break_time_answer)), ("Your answer does not have the correct number of rows.")
         # check 4: specific number
         id_to_check = break_time_answer["taxi_id"].iloc[0]
-        correct_ans = break_time_answer.loc[break_time_answer"taxi_id"].eq(id_to_check) & break_time_answer["prev_break"].notna(), "prev_break"]
+        correct_ans = break_time_answer.loc[break_time_answer["taxi_id"].eq(id_to_check) & break_time_answer["prev_break"].notna(), "prev_break"]
         submitted_ans = results.loc[results["taxi_id"].eq(id_to_check) & results["prev_break"].notna(), "prev_break"]
         if len(correct_ans) > 0:
             assert (correct_ans.min() == submitted_ans.min()), ("The results don't look right. Try again.")

--- a/learntools/sql_advanced/ex2.py
+++ b/learntools/sql_advanced/ex2.py
@@ -177,8 +177,8 @@ class BreakTime(CodingProblem):
         correct_ans = break_time_answer.loc[break_time_answer["taxi_id"].eq(id_to_check) & break_time_answer["prev_break"].notna(), "prev_break"]
         submitted_ans = results.loc[results["taxi_id"].eq(id_to_check) & results["prev_break"].notna(), "prev_break"]
         if len(correct_ans) > 0:
-            assert (correct_ans.min() == submitted_ans.min()), ("The results don't look right. Try again.")
-            assert (correct_ans.max() == submitted_ans.max()), ("The results don't look right. Try again.")
+            assert correct_ans.min() == submitted_ans.min(), "The results don't look right. Try again."
+            assert correct_ans.max() == submitted_ans.max(), "The results don't look right. Try again."
 
     _solution = CS( \
 """


### PR DESCRIPTION
The following items have errors that prevent successful completion of the exercises, even with the official solution. The errors are one of two variations:
- operation for a single numeric value tries to act on a list-like object
- operations fail when encountering an NA value

Commit messages and diff show the four files changed.

Discussion at https://www.kaggle.com/discussions/product-feedback/461240 

Issue #476 
