### PR TITLE
Sort the results before comparison

### DIFF
--- a/learntools/sql/ex6.py
+++ b/learntools/sql/ex6.py
@@ -186,14 +186,17 @@ bigquery_experts_results = bigquery_experts_query_job.to_dataframe()
         assert ('group by' in lower_query), ('Your query should have a **GROUP BY** clause.')
         assert ('count' in lower_query), ('Your query should have a **COUNT** in the **SELECT** statement.')
         assert ('%bigquery' in lower_query), ('Your **WHERE** clause is not filtering on the "bigquery" tag correctly.')
+
         # check 2: column names
         results.columns = [c.lower() for c in results.columns]
         assert ('user_id' in results.columns), ('You do not have a `user_id` column in your results.')
         assert ('number_of_answers' in results.columns), ('You do not have a `number_of_answers` column in your results.')
+
         # check 3: correct user IDs
         correct_ids = bigquery_experts_answer.loc[bigquery_experts_answer.user_id.notna(), "user_id"].unique()
         submitted_ids = results.loc[results.user_id.notna(), "user_id"].unique()
-        assert np.array_equal(correct_ids, submitted_ids), 'You seem to have the wrong values in the `user_id` column.'
+        assert np.array_equal(np.sort(correct_ids), np.sort(submitted_ids)), 'You seem to have the wrong values in the `user_id` column.'
+
         # check 4: check one value from other column
         first_id = list(bigquery_experts_answer["user_id"])[0]
         correct_num = int(bigquery_experts_answer[bigquery_experts_answer["user_id"] == first_id]["number_of_answers"])


### PR DESCRIPTION
The SQL statements don't contain an `ORDER BY` clause, so the ordering can't be an intentional check for this exercise. This exercise happens to work most of the time because BigQuery tends to return results in the same order, but sometimes it doesn't. Learn users shouldn't have to deal with this non-determinism in the check.

http://b/415948668