### PR TITLE
Use the `KAGGLE_LEARN_SESSION_ID`

### DIFF
--- a/learntools/core/tracking.py
+++ b/learntools/core/tracking.py
@@ -84,14 +84,13 @@ def track_using_kagglesdk(event):
     request.value_towards_completion = event.get('valueTowardsCompletion', 0.0)
     request.interaction_type = interaction_type_to_kagglesdk(event)
     request.outcome_type = outcome_type_to_kagglesdk(request.interaction_type, event)
+    request.fork_parent_kernel_session_id = os.environ.get('KAGGLE_LEARN_SESSION_ID')
 
     question_type = question_type_to_kagglesdk(event)
     if question_type:
         request.question_type = question_type
 
     # TODO(b/379083750): the following items are still TBD
-    #   - set request.fork_parent_kernel_session_id
-    #   - automatically handle authorization in KaggleClient
     #   - post the nudge information back to the client
 
     client = KaggleClient()


### PR DESCRIPTION
This environment variable was added in kaggleazure PR 36128. It is set on all Learn sessions. It refers to the version of the exercise the user forked from.

Note that this is all still behind a feature flag, so this code is a no-op for now.

http://b/379083750