### PR TITLE
fix - using input.shape instead of input_shape for layers which is not available anymore

### DIFF
--- a/learntools/deep_learning_intro/ex2.py
+++ b/learntools/deep_learning_intro/ex2.py
@@ -61,10 +61,7 @@ model = keras.Sequential([
         assert (layer_classes == true_classes), \
             ("Your model doesn't have the correct kinds of layers. You should have five layers with classes: Dense, Dense, Dense, Dense.")
         # Check input shape
-        try:
-            input_shape = dense_layer.input_shape
-        except:
-            input_shape = None
+        input_shape = dense_layer.input.shape
         assert (input_shape == (None, inputs)), \
             ("Your model should have {} inputs. Make sure you answered the previous question correctly!".format(inputs))
         # Check activation functions
@@ -111,10 +108,7 @@ model = keras.Sequential([
         assert (layer_classes == true_classes), \
             ("Your model doesn't have the correct kinds of layers. You should have five layers with classes: Dense, Activation, Dense, Activation, Dense.")
 
-        try:
-            input_shape = model.layers[0].input_shape
-        except:
-            input_shape = None
+        input_shape = model.layers[0].input.shape
         assert (input_shape == (None, 8)), \
             ("Your model should have 8 inputs. Did you include the input shape to the first layer?")
         dense_activations = [layer.activation.__name__ for layer in model.layers]


### PR DESCRIPTION
**There is no attribute "input_shape" for a layer**

Using the **shape** property of the the **input** object from layers instead
  - using layer.input.shape instead of layer.input_shape


**attaching the screen short for more information**  
current state
<img width="793" height="393" alt="image" src="https://github.com/user-attachments/assets/1e207aa0-30f2-4fb4-a2e2-97478fbfa13f" />

after a workaround
<img width="701" height="463" alt="image" src="https://github.com/user-attachments/assets/740f8dfc-92d0-4cd2-9a5a-24033d473dad" />
 