### PR TITLE
fix(python): match multi_word_search solution arg with starter code

### DIFF
--- a/learntools/python/solns/multi_word_search.py
+++ b/learntools/python/solns/multi_word_search.py
@@ -1,6 +1,6 @@
 from learntools.python.solns.word_search import word_search
-def multi_word_search(documents, keywords):
+def multi_word_search(doc_list, keywords):
     keyword_to_indices = {}
     for keyword in keywords:
-        keyword_to_indices[keyword] = word_search(documents, keyword)
+        keyword_to_indices[keyword] = word_search(doc_list, keyword)
     return keyword_to_indices


### PR DESCRIPTION
The starter code template for `multi_word_search` in the "Strings and Dictionaries" exercise notebook (`notebooks/python/raw/ex_6.ipynb`) defines the function signature as:
`def multi_word_search(doc_list, keywords):`

However, the official solution in `learntools/python/solns/multi_word_search.py` defines it using `documents` as the first argument name:
`def multi_word_search(documents, keywords):`

This mismatch (using `documents` instead of `doc_list` in the solution) causes consistency issues and can lead to `NameError` for learners who try to adapt their starter code using the solution's body.

This PR updates the solution to use `doc_list` to match the starter code and maintain consistency with Question 2 (`word_search`), which also uses `doc_list`.